### PR TITLE
Let's see if -ffast-math makes a bigger difference on GCC in Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,17 @@ GITHUB_ACTIONS="true" make db
 # -4847 is "Ace-King offsuit" but you can choose any other hand if you prefer
 HOLDEMDB_PATH="/tmp/profiling_dust.perf" perf record -F max -g -o /tmp/profiling_dust.perf/regenerate_opening_book.perf -- bin/regenerate_opening_book_selftest -4847
 HOLDEMDB_PATH="/tmp/profiling_dust.gcc" bin/regenerate_opening_book_profiling -4847
-HOLDEMDB_PATH="/tmp/profiling_dust.x" instruments -t 'Time Profiler' -D /tmp/profiling_dust.x/regenerate_opening_book.trace -- bin/regenerate_opening_book-clang -4847
-
-gprof bin/regenerate_opening_book_profiling bin/gmon*.out
+HOLDEMDB_PATH="/tmp/profiling_dust.x" xcrun xctrace record --template 'CPU Profiler' --output /tmp/profiling_dust.x/regenerate_opening_book.trace --target-stdout - --launch -- bin/regenerate_opening_book-clang -4847
 
 cd /tmp/profiling_dust.perf
 perf report regenerate_opening_book.perf
+
+# Linux only:
+gprof bin/regenerate_opening_book_profiling bin/gmon*.out
+
+# macOS only:
+open /tmp/profiling_dust.x/regenerate_opening_book.trace
+
 ```
 
 ### Regenerate the opening book

--- a/holdem/Makefile
+++ b/holdem/Makefile
@@ -71,15 +71,18 @@ test:
 
 REGENERATE_OPENING_BOOK_SRC = unittests/regenerate_opening_book.cpp src/aiCache.cpp src/aiInformation.cpp src/ai.cpp src/engine.cpp src/engine_base.cpp src/inferentials.cpp src/holdemutil.cpp src/holdem2.cpp src/randomDeck.cpp
 
+# `-ffast-math` also? If you're not worried about floating point...
+# It manifests in the final result only within https://github.com/yuzisee/pokeroo/pull/16#discussion_r2336961785
+# but for now we'll leave it off since having an accurate DB seems preferred since the true runtime of reading from disk is super fast anyway
 db:
 	mkdir -v -p bin
 	echo '::group::Compile bin/regenerate_opening_book_selftest (perf can be used for profiling)'
-	clang++ $(CXXFLAGS) $(CXXFLAGS_EXTREME_SPEEDUP) -ffast-math -flto -g -fno-omit-frame-pointer -o bin/regenerate_opening_book_selftest -Isrc -D PROGRESSUPDATE=140 $(REGENERATE_OPENING_BOOK_SRC)
+	clang++ $(CXXFLAGS) $(CXXFLAGS_EXTREME_SPEEDUP) -flto -g -fno-omit-frame-pointer -o bin/regenerate_opening_book_selftest -Isrc -D PROGRESSUPDATE=140 $(REGENERATE_OPENING_BOOK_SRC)
 	echo '::endgroup::'
 	date
 	echo '::group::Compile bin/regenerate_opening_book (full speed, i.e `-fno-exceptions -fno-rtti` and no profiling)'
 	# clang++ $(CXXFLAGS) $(CXXFLAGS_EXTREME_SPEEDUP) -fno-exceptions -fno-rtti -o bin/regenerate_opening_book-clang -Isrc -D PROGRESSUPDATE=140  $(REGENERATE_OPENING_BOOK_SRC)
-	g++ $(CXXFLAGS) $(CXXFLAGS_EXTREME_SPEEDUP) -ffast-math -flto -fno-exceptions -fno-rtti -o bin/regenerate_opening_book -Isrc -D PROGRESSUPDATE=140  $(REGENERATE_OPENING_BOOK_SRC)
+	g++ $(CXXFLAGS) $(CXXFLAGS_EXTREME_SPEEDUP) -flto -fno-exceptions -fno-rtti -o bin/regenerate_opening_book -Isrc -D PROGRESSUPDATE=140  $(REGENERATE_OPENING_BOOK_SRC)
 	echo '::endgroup::'
 	date
 	echo '::group::Compile bin/regenerate_opening_book_profiling (`g++ -pg` instead of clang++) use gprof to inspect'


### PR DESCRIPTION
I did the `-flto` thing in case it interferes with `g++ … -g -pg` but it remains to be seen whether that was an issue