### PR TITLE
Does changing the 2D array into a bitset create a significant speedup? [DealRemainder::LockNewAddend / DealRemainder::UpdateSameSuits / DealRemainder::OmitSet]

### DIFF
--- a/holdem/src/engine.cpp
+++ b/holdem/src/engine.cpp
@@ -22,9 +22,9 @@
 #include "holdem2.h"
 #include "ai.h"
 
-// TODO(from joseph): Optimize data layout for cache utilization
-// return (addendSameSuit_bits >> (suitNumA * 4 + suitNumB)) & 1;
-#define isAddendSameSuit(suitA, suitB) ( this->addendSameSuit[(suitA)][(suitB)] )
+#define isAddendSameSuit(suitA, suitB) static_cast<bool>(( this->addendSameSuit_bits >> (suitA * 4 + suitB)) & 1 )
+// addendSameSuit_bits is the faster bitmask version of the old `bool…[4][4]` code:
+// #define isAddendSameSuit(suitA, suitB) ( this->addendSameSuit[(suitA)][(suitB)] )
 
 float64 DealRemainder::DealCard(Hand& h)
 {
@@ -168,9 +168,9 @@ void DealRemainder::OmitSet(const CommunityPlus& setOne, const CommunityPlus& se
 
 }
 
-// TODO(from joseph): Optimize data layout for cache utilization
-// addendSameSuit_bits &= (1 << (suitNumA * 4 + suitNumB));
-#define addendSetStillSameSuit(suitA, suitB, stillSame) do { this->addendSameSuit[(suitA)][(suitB)] &= (stillSame); } while (0)
+#define addendSetStillSameSuit(suitA, suitB, stillSame) do { if (!(stillSame)) { this->addendSameSuit_bits &= ~(1 << (suitA * 4 + suitB)); } } while (0)
+// addendSameSuit_bits is the faster bitmask version of the old `bool…[4][4]` code:
+// #define addendSetStillSameSuit(suitA, suitB, stillSame) do { this->addendSameSuit[(suitA)][(suitB)] &= (stillSame); } while (0)
 
 void DealRemainder::UpdateSameSuits()
 {

--- a/holdem/src/engine.h
+++ b/holdem/src/engine.h
@@ -36,7 +36,8 @@ class DealRemainder : public virtual DealableOrderedDeck
 
         void UpdateSameSuits();
 
-   		bool addendSameSuit[4][4];
+   		// bool addendSameSuit[4][4];
+   		uint16 addendSameSuit_bits; // Bitmask implementation of the old `bool…[4][4]` code
 
 	public:
 
@@ -69,6 +70,8 @@ class DealRemainder : public virtual DealableOrderedDeck
             addendSum.SetUnique(other.addendSum);
             justDealt.SetUnique(other.justDealt);
 
+            addendSameSuit_bits = other.addendSameSuit_bits;
+            /*
             for( int8 i=0; i<4 ; ++i )
             {
                 for( int8 j=0; j<4 ; ++j )
@@ -76,12 +79,15 @@ class DealRemainder : public virtual DealableOrderedDeck
                     addendSameSuit[i][j] = other.addendSameSuit[i][j];
                 }
             }
+            */
 
 
         }
 
 		DealRemainder() : DealableOrderedDeck()
 		{//They start true, and once two suits are different, there is no changing it. They stay different forever
+            addendSameSuit_bits = ~0;
+        		/*
             for( int8 i=0; i<4 ; ++i )
             {
                 for( int8 j=0; j<4 ; ++j )
@@ -89,6 +95,7 @@ class DealRemainder : public virtual DealableOrderedDeck
                     addendSameSuit[i][j] = true;
                 }
             }
+            */
 
             justDealt.SetEmpty();
 		}


### PR DESCRIPTION
Special thanks to the original refactor from https://github.com/yuzisee/pokeroo/pull/23

In thie current pull request we replace `bool addendSameSuit[4][4];` → `uint8 addendSameSuit_bits;` 