### PR TITLE
Split pearson_kurtosis into numerator and denominator to evaluate numerical stability

### DIFF
--- a/holdem/src/aiCache.cpp
+++ b/holdem/src/aiCache.cpp
@@ -183,7 +183,8 @@ void StatsManager::holdemWtoJSON ( std::stringstream& dataf, const DistrShape& d
   dataf << "  \"improve_numerator\": " << dPCT.improve_numerator << "," << std::endl;
   dataf << "  \"skew_numerator\": " << dPCT.skew_numerator << "," << std::endl;
   dataf << "  \"skew_denominator\": " << dPCT.skew_denominator << "," << std::endl;
-  dataf << "  \"pearson_kurtosis\": " << dPCT.pearson_kurtosis << "," << std::endl;
+  dataf << "  \"pearson_kurtosis_numerator\": " << dPCT.pearson_kurtosis_numerator << "," << std::endl;
+  dataf << "  \"pearson_kurtosis_denominator\": " << dPCT.pearson_kurtosis_denominator << "," << std::endl;
   dataf << "  \"_COARSE_COMMUNITY_NUM_BINS\": " << COARSE_COMMUNITY_NUM_BINS;
   dataf << std::endl << "}" << std::endl;
 }

--- a/holdem/src/inferentials.cpp
+++ b/holdem/src/inferentials.cpp
@@ -47,7 +47,7 @@ DistrShape::DistrShape(float64 count, StatResult worstPCT, StatResult meanOveral
 ,
 mean(meanOverall), best(bestPCT), worst(worstPCT)
 ,
-avgDev(0), stdDev(0), improve_numerator(0), skew_numerator(0), skew_denominator(0), pearson_kurtosis(0)
+avgDev(0), stdDev(0), improve_numerator(0), skew_numerator(0), skew_denominator(0), pearson_kurtosis_numerator(0), pearson_kurtosis_denominator(0)
 {
     for (size_t k=0; k<COARSE_COMMUNITY_NUM_BINS; ++k) {
         coarseHistogram[k].wins = 0.0;
@@ -62,7 +62,8 @@ const DistrShape & DistrShape::operator=(const DistrShape& o)
 {
     avgDev = o.avgDev;
     improve_numerator = o.improve_numerator;
-    pearson_kurtosis = o.pearson_kurtosis;
+    pearson_kurtosis_numerator = o.pearson_kurtosis_numerator;
+    pearson_kurtosis_denominator = o.pearson_kurtosis_denominator;
     mean = o.mean;
     n = o.n;
     skew_numerator = o.skew_numerator;
@@ -114,7 +115,7 @@ void DistrShape::AddVal(const StatResult &x)
 	avgDev += fabs(d1);
 	stdDev += d2;
 	skew_numerator += d3;
-	pearson_kurtosis += d4;
+	pearson_kurtosis_numerator += d4;
 
 	if( d > 0 ){
 		improve_numerator += occ;
@@ -128,6 +129,7 @@ void DistrShape::Complete(float64 mag)
 {
 	normalize(mag);
 	skew_denominator = mag*mag*mag;
+	pearson_kurtosis_denominator = mag*mag*mag*mag;
 	Complete();
 }
 
@@ -139,12 +141,7 @@ void DistrShape::Complete()
 	stdDev = sqrt(stdDev);
 
 	skew_denominator *= n*o2*stdDev;
-	pearson_kurtosis /= n*o2*o2;
-	// kurtosis -= 3.0
-	// So...  when we had the old `kurtosis -= 3.0;` line in here, the ASM materializes  `1/mag` early and uses it consistently for scalar and vector updates;
-	//        after removing the `-= 3.0; `thing, it will first build `mag^2, mag^3, mag^4` and then derives/uses the reciprocal for scaling
-
-	// It seems like removing the subtraction gives more room for GCC optimizations (since now almost everything in here is an add or divide of more or less combinations of the same underlying quantities
+	pearson_kurtosis_denominator *= n*o2*o2;
 }
 
 /**
@@ -155,7 +152,6 @@ void DistrShape::normalize(float64 mag)
 {
 	avgDev /= mag;
 	stdDev /= mag*mag;
-	pearson_kurtosis /= mag*mag*mag*mag;
 
     best.scaleOrdinateOnly(1.0 / mag);
     worst.scaleOrdinateOnly(1.0 / mag);

--- a/holdem/src/inferentials.h
+++ b/holdem/src/inferentials.h
@@ -445,7 +445,8 @@ public:
 	float64 skew_numerator;
 	float64 skew_denominator;
 
-	float64 pearson_kurtosis;
+	float64 pearson_kurtosis_numerator;
+	float64 pearson_kurtosis_denominator;
 
 	//positive or negative ("Distributions with positive skew have larger means than medians.")
 	inline constexpr float64 skew() const {
@@ -454,10 +455,10 @@ public:
 
 	//risk-reward magnifier (high k is high risk high reward, long tail)
 	inline constexpr float64 kurtosis() const {
-	  return pearson_kurtosis - 3.0;
+	  return pearson_kurtosis_numerator / pearson_kurtosis_denominator - 3.0;
   }
 
- // Return the fraction of outcomes that cause your gain function f(x) to be above vs. below 1.0
+  // Return the fraction of outcomes that cause your gain function f(x) to be above vs. below 1.0
   // ...but instead of [0.0..1.0] we rescale to [-1.0..+1.0]
   inline constexpr float64 improve() const {
     // Rescale from

--- a/holdem/unittests/holdemjson.py
+++ b/holdem/unittests/holdemjson.py
@@ -76,7 +76,8 @@ def holdem_w_to_json(holdemc_filename: str) -> str:
         holdem_w_json["improve_numerator"] = read_typed_float(f)
         holdem_w_json["skew_numerator"] = read_typed_float(f)
         holdem_w_json["skew_denominator"] = read_typed_float(f)
-        holdem_w_json["pearson_kurtosis"] = read_typed_float(f)
+        holdem_w_json["pearson_kurtosis_numerator"] = read_typed_float(f)
+        holdem_w_json["pearson_kurtosis_denominator"] = read_typed_float(f)
         holdem_w_json['_COARSE_COMMUNITY_NUM_BINS'] = COARSE_COMMUNITY_NUM_BINS
 
         no_leftover = f.read(1)


### PR DESCRIPTION
This is the original first draft of https://github.com/yuzisee/pokeroo/pull/24 and in the past this has been a better direct jump than something like https://github.com/yuzisee/pokeroo/pull/32 but we're hoping that with https://github.com/yuzisee/pokeroo/pull/34 merged things will hopefully be a bit more predictable?