### PR TITLE
Abort if we can tell the unit test is going to fail

### DIFF
--- a/holdem/src/aiCache.cpp
+++ b/holdem/src/aiCache.cpp
@@ -301,6 +301,9 @@ void StatsManager::Query(DistrShape* dPCT,
             {
                 std::cerr << "Error reading " << datafilename << endl;
                 dataserial.close();
+                #ifdef RTTIASSERT
+                  exit(76); // EX_PROTOCOL
+                #endif
             }
         }else
         {
@@ -484,6 +487,9 @@ void StatsManager::QueryDefense(CallCumulation& q, const CommunityPlus& withComm
             {
                 std::cerr << "Error reading " << datafilename << endl;
                 dataserial.close();
+                #ifdef RTTIASSERT
+                  exit(76); // EX_PROTOCOL
+                #endif
             }
         }else
 	{


### PR DESCRIPTION
If you changed the serialization format/protocol but didn't update the gold DBs, the unit test currently times out instead of failing. This should fix that

e.g.  https://github.com/yuzisee/pokeroo/actions/runs/17693487068/job/50290099186