### PR TITLE
Fix spurious test failures for now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ e.g.
 rm -r /tmp/profiling_dust.perf /tmp/profiling_dust.gcc /tmp/profiling_dust.x
 mkdir -vp /tmp/profiling_dust.perf /tmp/profiling_dust.gcc /tmp/profiling_dust.x
 cd holdem
+# [!WARNING]
+# When building `bin/regenerate_opening_book_profiling` you'll also need -pg in the Makefile in order to generate `gmon.out` but you probably have to take out `-flto` first because these two flags don't interact well
 GITHUB_ACTIONS="true" make db
 # -4847 is "Ace-King offsuit" but you can choose any other hand if you prefer
 HOLDEMDB_PATH="/tmp/profiling_dust.perf" perf record -F max -g -o /tmp/profiling_dust.perf/regenerate_opening_book.perf -- bin/regenerate_opening_book_selftest -4847

--- a/holdem/Makefile
+++ b/holdem/Makefile
@@ -94,7 +94,9 @@ db:
 	echo '::endgroup::'
 	date
 	echo '::group::Compile bin/regenerate_opening_book_profiling (`g++ -pg` instead of clang++) use gprof to inspect'
-	g++ $(CXXFLAGS) $(CXXFLAGS_HOLDEMDB_CHAIN) -g -pg -o bin/regenerate_opening_book_profiling -Isrc -D PROGRESSUPDATE=140 -ffast-math $(REGENERATE_OPENING_BOOK_SRC)
+	g++ $(CXXFLAGS) $(CXXFLAGS_HOLDEMDB_CHAIN) -flto -g -fno-omit-frame-pointer -o bin/regenerate_opening_book_profiling -Isrc -D PROGRESSUPDATE=140 -ffast-math $(REGENERATE_OPENING_BOOK_SRC)
+	# TODO(from joseph): It ought to be possible to `-pg` here, but seemingly that interferes with `-flto` so we'd have to remove that first.
+	#                    In the meantime, we try to match `bin/regenerate_opening_book_selftest` so we can compare results during Github Actions tests
 	echo '::endgroup::'
 	# [!NOTE]
 	# `.github/actions/selftest_db/action.yml` will randomly select between Clang (bin/regenerate_opening_book_selftest) and GCC (bin/regenerate_opening_book_profiling) to ensure that both will produce identical results


### PR DESCRIPTION
If we want to profile later we can find some other way to do that. For now it's more important for the tests to be reliable. Plus, this probably runs faster overall.