### PR TITLE
Speed up unit tests, I think

### DIFF
--- a/holdem/Makefile
+++ b/holdem/Makefile
@@ -94,8 +94,8 @@ db:
 	echo '::endgroup::'
 	date
 	echo '::group::Compile bin/regenerate_opening_book_profiling (`g++ -pg` instead of clang++) use gprof to inspect'
-	g++ $(CXXFLAGS) $(CXXFLAGS_HOLDEMDB_CHAIN) -g -pg -o bin/regenerate_opening_book_profiling -Isrc -D PROGRESSUPDATE=140 $(REGENERATE_OPENING_BOOK_SRC)
-	# TODO(from joseph): Does it even make sense to `-pg` without `-flto` though? My understanding is that these two flags will interfere, but if we don't profile the actual `-flto` result will it be accurate enough?
+	g++ $(CXXFLAGS) $(CXXFLAGS_HOLDEMDB_CHAIN) -g -pg -flto -o bin/regenerate_opening_book_profiling -Isrc -D PROGRESSUPDATE=140 $(REGENERATE_OPENING_BOOK_SRC)
+	# ^^^ TODO(from joseph): You'll need to add `-pg` in order to generate `gmon.out` but understanding is that `-pg` interferes with `-flto`, so you may need to remove `-flto` first. Having said that, if we don't profile the actual `-flto` result will it be accurate enough?
 	echo '::endgroup::'
 	# [!NOTE]
 	# `.github/actions/selftest_db/action.yml` will randomly select between Clang (bin/regenerate_opening_book_selftest) and GCC (bin/regenerate_opening_book_profiling) to ensure that both will produce identical results


### PR DESCRIPTION
It seems we get a 2.5× speedup with _both_ `-flto` and removing `-pg`.