### PR TITLE
Bugfix in ScalarFunctionModel::FindZero with additional assertions added to FoldOrCall::predictedRaiseToThisRound

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 holdem/objs/
+holdem/bin/
+holdem/lib/
+
+tags
+
+**/.DS_Store

--- a/holdem/src/BluffGainInc.cpp
+++ b/holdem/src/BluffGainInc.cpp
@@ -28,6 +28,10 @@
 
 void AutoScalingFunction::query(float64 sliderx, float64 x)
 {
+float64 yl;
+float64 yr;
+float64 fd_yl;
+float64 fd_yr;
 
     last_x = x;
     last_sliderx = sliderx;
@@ -59,8 +63,10 @@ void AutoScalingFunction::query(float64 sliderx, float64 x)
 
         if( slider >= 1 )
         {
-            y = right.f(x);
-            dy = right.fd(x, yr);
+            yr = right.f(x);
+            fd_yr = right.fd(x, yr);
+
+            y = yr; dy = fd_yr;
 
 #ifdef DEBUG_TRACE_SEARCH
             if(bTraceEnable) std::cout << "\t\t\tbMax" << std::flush;
@@ -69,7 +75,7 @@ void AutoScalingFunction::query(float64 sliderx, float64 x)
         else if( slider <= 0 )
         {
             yl = left.f(x);
-            fd_yl = left.fd(x,yl);
+            fd_yl = left.fd(x, yl);
 
             y = yl; dy = fd_yl;
 

--- a/holdem/src/BluffGainInc.h
+++ b/holdem/src/BluffGainInc.h
@@ -59,11 +59,6 @@ protected:
     float64 y;
     float64 dy;
 
-    float64 yl;
-    float64 yr;
-    float64 fd_yl;
-    float64 fd_yr;
-
 public:
 
 #ifdef TRANSFORMED_AUTOSCALES
@@ -249,7 +244,7 @@ public:
     firstFoldToRaise(-1)
     {
     }
-    
+
     /*
      StateModel(ExactCallBluffD &c, IFunctionDifferentiable &functionL, IFunctionDifferentiable &functionR) : ScalarFunctionModel(c.tableinfo->chipDenom()),HoldemFunctionModel(c.tableinfo->chipDenom(),c.tableinfo)
      ,last_x(-1)
@@ -310,4 +305,3 @@ public:
 
 
 #endif
-

--- a/holdem/src/callSituation.cpp
+++ b/holdem/src/callSituation.cpp
@@ -312,8 +312,10 @@ MeanOrRank FoldOrCall::suggestMeanOrRank() const {
     {}
 
 
+    // [!TIP]
+    // This is just a simple sum of a finite geometric series.
     float64 RaiseRatio::f(const float64 r)  {
-        float64 expected = fS;
+        float64 expected = fS; // We would like to reach this target amount at the end
         float64 actual = 0.0;
         float64 next = fA;
         for (int i=1;i<=fK;++i) {
@@ -337,7 +339,10 @@ MeanOrRank FoldOrCall::suggestMeanOrRank() const {
 
 float64 RaiseRatio::FindRatio() {
 
-    const float64 reraisedByFinalRatio = fS / fA; // If fK == 1 this would be the solution. If fK < 1 the required ratio only gets lower.
+    const float64 reraisedByFinalRatio = fS / fA;
+    // If it's the final betting round this would be the solution.
+    //         ^^^ i.e. `fK == 1` ^^^
+    // If fK > 1 the required ratio only gets lower.
 
     return FindZero(1.0, reraisedByFinalRatio, false);
 }
@@ -377,6 +382,15 @@ float64 FoldOrCall::predictedRaiseToThisRound(float64 actualBetToCall, float64 h
     if(is_nan(r)) {
         std::cout << "raiseRatio(" << quantum << "," << myRaiseBy << "," << reraisedByFinal << "," << static_cast<int>(spreadRaisesOverThisManyBettingRounds) << ") NaN'ed" << std::endl;
         exit(1);
+    }
+    if( (r < 1.0) && (start < reraisedByFinal)) {
+      std::cout << "We are outside the range? Raising would never cause the pot to SHRINK but... raiseRatio.FindRatio() returned " << r << " during FoldOrCall::predictedRaiseToThisRound" << std::endl;
+      exit(1);
+    }
+    if ((reraisedByFinal + std::numeric_limits<double>::epsilon()) / (start - std::numeric_limits<double>::epsilon()) < r - std::numeric_limits<double>::epsilon()) {
+      std::cout << "We want to answer the question of \"if their *target* raise is to reach reraisedByFinal: knowing there are `spreadRaisesOverThisManyBettingRounds` remaining, how much will they raise _this round_?\"  And, yet, raiseRatio.FindRatio() returned " << r
+      << " which would exceed their target of " << reraisedByFinal << " if the first raise is " << start << std::endl;
+      exit(1);
     }
 #endif // DEBUGASSERT
 

--- a/holdem/src/functionbase.cpp
+++ b/holdem/src/functionbase.cpp
@@ -671,8 +671,12 @@ float64 ScalarFunctionModel::FindZero(float64 x1, float64 x2, bool bRoundToQuant
     float64 y2 = f(x2);
 
     // See unittests/main.cpp#testRegression_028
-    if (y1 == 0) return y1;
-    if (y2 == 0) return y2;
+    if (y1 == 0) {
+      return x1;
+    }
+    if (y2 == 0) {
+      return x2;
+    }
 
     if( y1 > 0 && y2 > 0 ) //x1*x2 > 0
     {


### PR DESCRIPTION
First discovered during https://github.com/yuzisee/pokeroo/pull/50#pullrequestreview-3227582481

Bug was originally introduced by https://github.com/yuzisee/pokeroo/commit/9f6bf7a97f63b0c1c23840d50653aec0a2c3bf33