### PR TITLE
Still trying to track down all the usages of `ExpectedCallD::RiskLoss`

### DIFF
--- a/holdem/src/callPrediction.cpp
+++ b/holdem/src/callPrediction.cpp
@@ -1136,7 +1136,10 @@ void ExactCallBluffD::query(const float64 betSize)
                     const float64 eaRkFoldPartial = 0;
 
                     ///topTwoOfThree is on a player-by-player basis
+                    // [!NOTE]
+                    // This next line DOES write to `nextFold`
                     nextFoldPartial = bottomThreeOfFour(eaFold.first,meanFold.first,rankFold,eaRkFold,eaFold.second,meanFold.second,rankFoldPartial,eaRkFoldPartial,nextFold);
+                    ///topTwoOfThree is on a player-by-player basis
                     //nextFold = (eaFold+meanFold+rankFold+eaRkFold)/4;
                     //nextFoldPartial=(eaFoldPartial+meanFoldPartial+rankFoldPartial+eaRkFoldPartial)/4;
 

--- a/holdem/src/callPrediction.h
+++ b/holdem/src/callPrediction.h
@@ -249,6 +249,7 @@ struct TableSpec {
 
 // Based on the bet size I am making, how many times can the opponent afford to fold?
 // We use this value to determine our expected hand strength assuming the opponent knows what we have.
+// By directly establishing the opponent's hand strength this way (as a function of our bet size), there is no need to offet "RiskLoss" anymore. As such, this obsoletes ExpectedCallD::RiskLoss
 class OpponentHandOpportunity {
 public:
     // facedHands: What does the opponent think his/her win percentage is based on rarity?

--- a/holdem/src/callSituation.cpp
+++ b/holdem/src/callSituation.cpp
@@ -245,6 +245,11 @@ const Player * ExpectedCallD::ViewPlayer() const {
 
 // DEPRECATED: Use OpponentHandOpportunity and CombinedStatResultsPessemistic instead.
 // TODO: Let's say riskLoss is a table metric. In that case, if you use mean it's callcumu always.
+// At the time of this writing...
+//  + src/stratFear.h:ScalarPWinFunction uses ExactCallBluffD but it's inconclusive.
+//  + src/stratPosition.h has `DeterredGainStrategy` and `ImproveGainStrategy` which both have varying levels of ExactCallBluffD
+//  + src/stratPosition.cpp also creates StateModel objects in all three of ImproveGainStrategy::MakeBet & DeterredGainStrategy::MakeBet & PureGainStrategy::MakeBet
+//                          so do they all eventually call into RiskLoss?
 template<typename T> float64 ExpectedCallD::RiskLoss(const struct HypotheticalBet & hypotheticalRaise, CallCumulationD<T, OppositionPerspective> * useMean, float64 * out_dPot) const
 {
     const float64 raiseTo = hypotheticalRaise.hypotheticalRaiseTo;

--- a/holdem/src/functionmodel.h
+++ b/holdem/src/functionmodel.h
@@ -298,6 +298,9 @@ public:
  *  + Pass in two different StatResult objects and we'll use the geometric mean of them instead.
  *
  * DEPRECATED( Use PureStatResultGeom instead. It's simpler, more robust (e.g. fewer knobs), and should be closer to optimal. )
+ * At the time of this writing...
+ *  + src/stratPosition.cpp:PureGainStrategy uses PureStatResultGeom
+ *  + src/stratPosition.cpp:ImproveGainStrategy uses CombinedStatResultsGeom
  */
 class CombinedStatResultsGeom : public virtual ICombinedStatResults {
 private:


### PR DESCRIPTION
The purpose of OpponentHandOpportunity is to be some kind of FoldGainModel or FoldWaitLengthModel but from the opposition perspective

The purpose of CombinedStatResultsPessemistic is to adjust the win percentage rather than the gain, which is more direct than what ExactCallD::facedOdds_raise_Geom is doing