### PR TITLE
Expand ChipPositionState into HypotheticalBet

### DIFF
--- a/holdem/src/callPrediction.cpp
+++ b/holdem/src/callPrediction.cpp
@@ -19,7 +19,6 @@
  ***************************************************************************/
 
 #include "callPrediction.h"
-#include "callPredictionFunctions.h"
 #include "inferentials.h"
 #include <algorithm>
 
@@ -174,7 +173,7 @@ float64 ExactCallD::facedOdds_raise_Geom(const struct HypotheticalBet & hypothet
 
     return facedOdds_raise_Geom_forTest( startingPoint
                                         ,tableinfo->table->GetChipDenom()
-                                        ,tableinfo->RiskLoss(hypothetical, opponents, useMean, 0)
+                                        ,tableinfo->RiskLoss(hypothetical, useMean, 0)
                                         ,avgBlind
                                         ,hypothetical
                                         ,opponents
@@ -273,7 +272,7 @@ float64 ExactCallD::dfacedOdds_dpot_GeomDEXF(const struct HypotheticalBet & hypo
     {
     //USE FG for riskLoss
         float64 dRiskLoss_pot = std::numeric_limits<float64>::signaling_NaN();
-        tableinfo->RiskLoss(hypothetical, opponents, useMean, &dRiskLoss_pot);
+        tableinfo->RiskLoss(hypothetical, useMean, &dRiskLoss_pot);
 
         FoldGainModel myFG(tableinfo->chipDenom());
 
@@ -523,7 +522,7 @@ struct FacedOdds {
 
     this->pess = pr_call_pr_raiseby.facedOdds_raise_Geom(oppRaise,prev_w_r.pess, opponents, (&pr_call_pr_raiseby.fCore.foldcumu));
     #ifdef ANTI_CHECK_PLAY
-    if( bOppCouldCheck )
+    if( oppRaise.bCouldHaveChecked )
     {
         this->mean = 1;
         this->rank = 1;

--- a/holdem/src/callPrediction.cpp
+++ b/holdem/src/callPrediction.cpp
@@ -19,6 +19,7 @@
  ***************************************************************************/
 
 #include "callPrediction.h"
+#include "callPredictionFunctions.h"
 #include "inferentials.h"
 #include <algorithm>
 
@@ -164,33 +165,31 @@ float64 ExactCallBluffD::bottomTwoOfThree(float64 a, float64 b, float64 c, float
 */
 
 // useMean is a table metric here (see RiskLoss), so always use callcumu
-float64 ExactCallD::facedOdds_raise_Geom(const ChipPositionState & cps, float64 startingPoint, float64 incrRaise, float64 fold_bet, float64 opponents, bool bCheckPossible, bool bMyWouldCall, CallCumulationD * useMean) const
+float64 ExactCallD::facedOdds_raise_Geom(const struct HypotheticalBet & hypothetical, float64 startingPoint, float64 opponents, CallCumulationD * useMean) const
 {
 
-    float64 raiseto = cps.alreadyBet + incrRaise; //Assume this is controlled to be less than or equal to bankroll
     const playernumber_t N = tableinfo->handsDealt();
     const float64 avgBlind = tableinfo->table->GetBlindValues().OpportunityPerHand(N);
 
 
     return facedOdds_raise_Geom_forTest( startingPoint
                                         ,tableinfo->table->GetChipDenom()
-                                        ,raiseto
-                                        ,tableinfo->RiskLoss(cps.alreadyBet, cps.bankroll, opponents, raiseto, useMean, 0)
+                                        ,tableinfo->RiskLoss(hypothetical, opponents, useMean, 0)
                                         ,avgBlind
-                                        ,cps
-                                        ,fold_bet
+                                        ,hypothetical
                                         ,opponents
-                                        ,bCheckPossible
-                                        ,bMyWouldCall
                                         ,useMean
                                         );
 }
 
 float64 ExactCallD::facedOdds_raise_Geom_forTest(float64 startingPoint, float64 denom, float64 riskLoss, float64 avgBlind, const struct HypotheticalBet & hypotheticalRaise, float64 opponents, CallCumulationD * useMean)
 {
-  const struct ChipPositionState &cps = hypotheticalRaise.cps;
-    if( raiseto >= cps.bankroll )
+  const struct ChipPositionState &cps = hypotheticalRaise.bettorSituation;
+    if( hypotheticalRaise.hypotheticalRaiseTo >= cps.bankroll )
     {
+      // ^^^ By the way, this can essentially only happen when `hypotheticalRaise.hypotheticalRaiseTo == cps.bankroll`
+      //     See the `if(!oppRaise.bMoreThanAllIn())` block in `ExactCallD::accumulateOneOpponentPossibleRaises` which already controls `hypotheticalRaiseTo` to be less than or equal to bankroll
+
         const float64 w_r = 1-1.0/RAREST_HAND_CHANCE; // because an opponent would still _always_ raise with the best hand.
         if (startingPoint < w_r) {
             return w_r;
@@ -201,8 +200,8 @@ float64 ExactCallD::facedOdds_raise_Geom_forTest(float64 startingPoint, float64 
 
     FacedOddsRaiseGeom a(denom);
 
-	a.pot = cps.pot + (hypotheticalRaise.bWillGetCalled ? (raiseto-fold_bet) : 0);
-    a.raiseTo = raiseto;
+	a.pot = cps.pot + (hypotheticalRaise.bWillGetCalled ? (hypotheticalRaise.betIncrease()) : 0);
+    a.raiseTo = hypotheticalRaise.hypotheticalRaiseTo;
     a.fold_bet = hypotheticalRaise.fold_bet();
     a.bCheckPossible = hypotheticalRaise.bCouldHaveChecked;
     a.riskLoss = (hypotheticalRaise.bCouldHaveChecked) ? 0 : riskLoss;
@@ -242,19 +241,16 @@ float64 ExactCallD::facedOdds_raise_Geom_forTest(float64 startingPoint, float64 
 
 
 //Here, dbetsize/dpot = 0
-float64 ExactCallD::dfacedOdds_dpot_GeomDEXF(const ChipPositionState & cps, float64 incrRaise, float64 faced_bet, float64 w, float64 opponents, float64 dexfy,  bool bCheckPossible, bool bMyWouldCall, CallCumulationD * useMean) const
+float64 ExactCallD::dfacedOdds_dpot_GeomDEXF(const struct HypotheticalBet & hypothetical, float64 w, float64 opponents, float64 dexfy, CallCumulationD * useMean) const
 {
+  const struct ChipPositionState &cps = hypothetical.bettorSituation;
+
     if( w <= 0 ) return 0;
-    const float64 raiseto = cps.alreadyBet + incrRaise;
-	if( raiseto >= cps.bankroll - tableinfo->chipDenom()/2 ) return 0;
+    const float64 raiseto = hypothetical.hypotheticalRaiseTo;
+	if( hypothetical.bEffectivelyAllIn(tableinfo->chipDenom()) ) return 0;
 
 
-    if( faced_bet > cps.bankroll )
-    {
-        faced_bet = cps.bankroll;
-    }
-
-	const float64 retBet = bMyWouldCall ? (raiseto-faced_bet) : 0;
+	const float64 retBet = hypothetical.bWillGetCalled ? (hypothetical.betIncrease()) : 0;
 
     const int8 N = tableinfo->handsDealt();
     const float64 avgBlind = tableinfo->table->GetBlindValues().OpportunityPerHand(N);
@@ -270,16 +266,14 @@ float64 ExactCallD::dfacedOdds_dpot_GeomDEXF(const ChipPositionState & cps, floa
     const float64 C = fw/(cps.bankroll+cps.pot+retBet) ;
     const float64 h_times_remaining = std::pow( (cps.bankroll+cps.pot+retBet)/(cps.bankroll-raiseto), fw ) * (cps.bankroll - raiseto);
 
-
-
-    if(bCheckPossible)
+    if(hypothetical.bCouldHaveChecked)
     {
         return (h_times_remaining*C*dexfy) / (h_times_remaining*A);
     }else
     {
     //USE FG for riskLoss
         float64 dRiskLoss_pot = std::numeric_limits<float64>::signaling_NaN();
-        tableinfo->RiskLoss(cps.alreadyBet, cps.bankroll, opponents, raiseto, useMean, &dRiskLoss_pot);
+        tableinfo->RiskLoss(hypothetical, opponents, useMean, &dRiskLoss_pot);
 
         FoldGainModel myFG(tableinfo->chipDenom());
 
@@ -289,6 +283,14 @@ float64 ExactCallD::dfacedOdds_dpot_GeomDEXF(const ChipPositionState & cps, floa
         myFG.waitLength.load(cps, avgBlind);
         myFG.waitLength.opponents = opponents;
         //myFG.dw_dbet = 0; //Again, we don't need this
+
+        // It seems to be that:
+        //  (i) The underlying `accumulateOneOpponentPossibleRaises` and thus `ExactCallD::query` is a search over ExactCallD::query's `betSize`
+        //      so when we take the derivative, we want to sample the derivative at the value of `betSize` corresponding to ExactCallD::query
+        //  (ii) The FoldGain of a position is based on the bet you're facing (and would consider folding against INSTEAD OF following through on HypotheticalBet)
+        //       Well, that bet you're facing is exactly `hypothetical.hypotheticalRaiseAgainst`
+        // and… well what do you know? These two (i) and (ii) are the same value.
+        const float64 faced_bet = hypothetical.hypotheticalRaiseAgainst;
 
         #ifdef DEBUGASSERT
           if (std::isnan(dRiskLoss_pot)) {
@@ -516,10 +518,10 @@ struct FacedOdds {
   }
 
   // TODO(from yuzisee): Raises are now Algb instead of Geom?
-  void init_facedOdds_raise(ExactCallD & pr_call_pr_raiseby, const ChipPositionState & oppCPS, const FacedOdds &prev_w_r, const float64 oppRaiseMake, const float64 betSize, const bool bOppCouldCheck, const bool bMyWouldCall) {
+  void init_facedOdds_raise(ExactCallD & pr_call_pr_raiseby, const FacedOdds &prev_w_r, const struct HypotheticalBet& oppRaise) {
     const float64 opponents = pr_call_pr_raiseby.tableinfo->handsToShowdownAgainst();
 
-    this->pess = pr_call_pr_raiseby.facedOdds_raise_Geom(oppCPS,prev_w_r.pess, oppRaiseMake, betSize, opponents,bOppCouldCheck,bMyWouldCall,(&pr_call_pr_raiseby.fCore.foldcumu));
+    this->pess = pr_call_pr_raiseby.facedOdds_raise_Geom(oppRaise,prev_w_r.pess, opponents, (&pr_call_pr_raiseby.fCore.foldcumu));
     #ifdef ANTI_CHECK_PLAY
     if( bOppCouldCheck )
     {
@@ -528,8 +530,8 @@ struct FacedOdds {
     } else
     #endif
     {
-      this->mean = pr_call_pr_raiseby.facedOdds_raise_Geom(oppCPS,prev_w_r.mean, oppRaiseMake, betSize, opponents,bOppCouldCheck,bMyWouldCall,(&pr_call_pr_raiseby.fCore.callcumu));
-      this->rank = pr_call_pr_raiseby.facedOdds_raise_Geom(oppCPS,prev_w_r.rank, oppRaiseMake, betSize, opponents,bOppCouldCheck,bMyWouldCall,0);
+      this->mean = pr_call_pr_raiseby.facedOdds_raise_Geom(oppRaise,prev_w_r.mean, opponents, (&pr_call_pr_raiseby.fCore.callcumu));
+      this->rank = pr_call_pr_raiseby.facedOdds_raise_Geom(oppRaise,prev_w_r.rank, opponents, 0);
     }
   }
 
@@ -736,20 +738,20 @@ void ExactCallD::accumulateOneOpponentPossibleRaises(const int8 pIndex, ValueAnd
 
                          if (prev_w_r.assert_not_nan()) {
                           FacedOdds w_r_facedodds; // TODO(from joseph): Rename to noraiseRank or, rename noraiseRankD to w_r_facedodds_D
-                          w_r_facedodds.init_facedOdds_raise(*this, oppCPS, prev_w_r, oppRaise.betIncrease(), betSize, bOppCouldCheck, bMyWouldCall);
+                          w_r_facedodds.init_facedOdds_raise(*this, prev_w_r, oppRaise);
 
-                          const float64 noraiseRankD = dfacedOdds_dpot_GeomDEXF( oppCPS,oppRaise.betIncrease(),tableinfo->callBet(), w_r_facedodds.rank, opponents, totaldexf, bOppCouldCheck, bMyWouldCall ,0);
+                          const float64 noraiseRankD = dfacedOdds_dpot_GeomDEXF( oppRaise, w_r_facedodds.rank, opponents, totaldexf ,0);
 
                                 const ValueAndSlope noraisePess = {
                                   1.0 - fCore.foldcumu.Pr_haveWinPCT_strictlyBetterThan(w_r_facedodds.pess - EPS_WIN_PCT)  // 1 - ed()->Pr_haveWinPCT_orbetter(w_r_pess)
                                   ,
-                                  fCore.foldcumu.Pr_haveWorsePCT_continuous(w_r_facedodds.pess - EPS_WIN_PCT).second * dfacedOdds_dpot_GeomDEXF( oppCPS,oppRaise.betIncrease(),tableinfo->callBet(),w_r_facedodds.pess, opponents,totaldexf,bOppCouldCheck, bMyWouldCall, (&fCore.foldcumu))
+                                  fCore.foldcumu.Pr_haveWorsePCT_continuous(w_r_facedodds.pess - EPS_WIN_PCT).second * dfacedOdds_dpot_GeomDEXF( oppRaise, w_r_facedodds.pess, opponents,totaldexf, (&fCore.foldcumu))
                                 };
 
                                 const ValueAndSlope noraiseMean = {
                                   1.0 - fCore.callcumu.Pr_haveWinPCT_strictlyBetterThan(w_r_facedodds.mean - EPS_WIN_PCT) // 1 - ed()->Pr_haveWinPCT_orbetter(w_r_mean)
                                   ,
-                                  fCore.callcumu.Pr_haveWorsePCT_continuous(w_r_facedodds.mean - EPS_WIN_PCT).second * dfacedOdds_dpot_GeomDEXF( oppCPS,oppRaise.betIncrease(),tableinfo->callBet(),w_r_facedodds.mean, opponents,totaldexf,bOppCouldCheck, bMyWouldCall, (&fCore.callcumu))
+                                  fCore.callcumu.Pr_haveWorsePCT_continuous(w_r_facedodds.mean - EPS_WIN_PCT).second * dfacedOdds_dpot_GeomDEXF( oppRaise, w_r_facedodds.mean, opponents,totaldexf, (&fCore.callcumu))
                                 };
 
                           //nextNoRaise_A[i_step].v = w_r_facedodds.rank;

--- a/holdem/src/callPrediction.h
+++ b/holdem/src/callPrediction.h
@@ -101,8 +101,8 @@ class ExactCallD : public IExf
         float64 dfacedOdds_dbetSize_Geom(const ChipPositionState & cps, float64 humanbet, float64 dpot, float64 w, float64 n,  CallCumulationD * useMean) const;
 
 
-        float64 facedOdds_raise_Geom(const ChipPositionState & cps, float64 startingPoint, float64 incrbet_forraise, float64 fold_bet, float64 n, bool bCheckPossible, bool bMyWouldCall, CallCumulationD * useMean) const;
-        float64 dfacedOdds_dpot_GeomDEXF(const ChipPositionState & cps, float64 incrbet_forraise, float64 fold_bet, float64 w, float64 opponents, float64 dexf, bool bCheckPossible, bool bMyWouldCall, CallCumulationD * useMean) const;
+        float64 facedOdds_raise_Geom(const struct HypotheticalBet & hypothetical, float64 startingPoint, float64 n, CallCumulationD * useMean) const;
+        float64 dfacedOdds_dpot_GeomDEXF(const struct HypotheticalBet & hypothetical, float64 w, float64 opponents, float64 dexf, CallCumulationD * useMean) const;
 
 
         void query(const float64 betSize, const int32 callSteps);

--- a/holdem/src/callPrediction.h
+++ b/holdem/src/callPrediction.h
@@ -110,7 +110,7 @@ class ExactCallD : public IExf
 
     // By default, startingPoint == 0.0
     // When using this function for the purposes of nextNoRaise_A, you'll want to start at the previous value to avoid rounding errors.
-    static float64 facedOdds_raise_Geom_forTest(float64 startingPoint, float64 denom, float64 raiseto, float64 riskLoss, float64 avgBlind, const ChipPositionState & cps, float64 fold_bet, float64 opponents, bool bCheckPossible, bool bMyWouldCall, CallCumulationD * useMean);
+    static float64 facedOdds_raise_Geom_forTest(float64 startingPoint, float64 denom, float64 riskLoss, float64 avgBlind, const struct HypotheticalBet & hypotheticalRaise, float64 opponents, CallCumulationD * useMean);
 
 
 

--- a/holdem/src/callSituation.cpp
+++ b/holdem/src/callSituation.cpp
@@ -244,7 +244,7 @@ const Player * ExpectedCallD::ViewPlayer() const {
 
 // DEPRECATED: Use OpponentHandOpportunity and CombinedStatResultsPessemistic instead.
 // TODO: Let's say riskLoss is a table metric. In that case, if you use mean it's callcumu always.
-float64 ExpectedCallD::RiskLoss(const struct HypotheticalBet & hypotheticalRaise, float64 opponents, CallCumulationD * useMean, float64 * out_dPot) const
+float64 ExpectedCallD::RiskLoss(const struct HypotheticalBet & hypotheticalRaise, CallCumulationD * useMean, float64 * out_dPot) const
 {
     const float64 raiseTo = hypotheticalRaise.hypotheticalRaiseTo;
     const int8 N = handsDealt(); // This is the number of people they would have to beat in order to ultimately come back and win the hand on the time they choose to catch you.

--- a/holdem/src/callSituation.h
+++ b/holdem/src/callSituation.h
@@ -76,7 +76,7 @@ public:
      * Since making a small bet does not allow an average opponent to profit via his/her opportunity cost of folding, your ``RiskLoss`` remains zero as long as your bet is suffciently small compared to an average opponent's opportunity.
      * The value returned by the RiskLoss function is used as a deterrent for raising too high.
      */
-    virtual float64 RiskLoss(const struct HypotheticalBet & hypotheticalRaise, float64 opponents, CallCumulationD * useMean, float64 * out_dPot = 0) const;
+    virtual float64 RiskLoss(const struct HypotheticalBet & hypotheticalRaise, CallCumulationD * useMean, float64 * out_dPot = 0) const;
     virtual float64 PushGain() const;
 
     virtual uint8 OppRaiseOpportunities(int8 oppID) const;

--- a/holdem/src/callSituation.h
+++ b/holdem/src/callSituation.h
@@ -76,7 +76,7 @@ public:
      * Since making a small bet does not allow an average opponent to profit via his/her opportunity cost of folding, your ``RiskLoss`` remains zero as long as your bet is suffciently small compared to an average opponent's opportunity.
      * The value returned by the RiskLoss function is used as a deterrent for raising too high.
      */
-    virtual float64 RiskLoss(float64 alreadyBet, float64 bankroll, float64 opponents, float64 raiseTo, CallCumulationD * useMean, float64 * out_dPot = 0) const;
+    virtual float64 RiskLoss(const struct HypotheticalBet & hypotheticalRaise, float64 opponents, CallCumulationD * useMean, float64 * out_dPot = 0) const;
     virtual float64 PushGain() const;
 
     virtual uint8 OppRaiseOpportunities(int8 oppID) const;

--- a/holdem/unittests/main.cpp
+++ b/holdem/unittests/main.cpp
@@ -880,11 +880,26 @@ namespace UnitTests {
     void testRegression_002b() {
         ChipPositionState oppCPS(2474,7.875,0,0, 0.0);
         // tableinfo->RiskLoss(0, 2474, 4, 6.75, 0, 0) = 0.0
+        HypotheticalBet hypothetical0 = {
+          oppCPS, 6.75 + oppCPS.alreadyBet,
+          std::numeric_limits<float64>::signaling_NaN(), // raiseBy is not needed for this test
+          4.5,
+          false,
+          true
+        };
+        float64 w_r_rank0 = ExactCallD::facedOdds_raise_Geom_forTest(0.0, 1.0 /* denom */, 0.0 /* RiskLoss */ , 0.31640625 /* avgBlind */
+                                                                     ,hypothetical0, 4,0);
         // tableinfo->RiskLoss(0, 2474, 4, 11.25, 0, 0) == 0.0
-        float64 w_r_rank0 = ExactCallD::facedOdds_raise_Geom_forTest(0.0, 1.0 /* denom */, 6.75 + oppCPS.alreadyBet, 0.0 /* RiskLoss */ , 0.31640625 /* avgBlind */
-                                                                     ,oppCPS,4.5, 4,false,true,0);
-        float64 w_r_rank1 = ExactCallD::facedOdds_raise_Geom_forTest(w_r_rank0, 1.0, 11.25 + oppCPS.alreadyBet, 0.0 ,  0.31640625
-                                                                     ,oppCPS, 4.5, 4,false,true,0);
+        HypotheticalBet hypothetical1 = {
+          oppCPS,
+          11.25 + oppCPS.alreadyBet,
+          std::numeric_limits<float64>::signaling_NaN(), // raiseBy is not needed for this test
+          4.5,
+          false,
+          true
+        };
+        float64 w_r_rank1 = ExactCallD::facedOdds_raise_Geom_forTest(w_r_rank0, 1.0, 0.0 ,  0.31640625
+                                                                     ,hypothetical1, 4,0);
 
         // The bug is: These two values, if otherwise equal, can end up being within half-quantum.
         assert(w_r_rank0 <= w_r_rank1);

--- a/holdem/unittests/main.cpp
+++ b/holdem/unittests/main.cpp
@@ -882,10 +882,8 @@ namespace UnitTests {
         // tableinfo->RiskLoss(0, 2474, 4, 6.75, 0, 0) = 0.0
         HypotheticalBet hypothetical0 = {
           oppCPS, 6.75 + oppCPS.alreadyBet,
-          std::numeric_limits<float64>::signaling_NaN(), // raiseBy is not needed for this test
-          4.5,
-          false,
-          true
+          std::numeric_limits<float64>::signaling_NaN(), // raiseBy is not needed for this test, unless you also want to test the derivative
+          4.5, false, true
         };
         float64 w_r_rank0 = ExactCallD::facedOdds_raise_Geom_forTest(0.0, 1.0 /* denom */, 0.0 /* RiskLoss */ , 0.31640625 /* avgBlind */
                                                                      ,hypothetical0, 4,0);
@@ -893,10 +891,8 @@ namespace UnitTests {
         HypotheticalBet hypothetical1 = {
           oppCPS,
           11.25 + oppCPS.alreadyBet,
-          std::numeric_limits<float64>::signaling_NaN(), // raiseBy is not needed for this test
-          4.5,
-          false,
-          true
+          std::numeric_limits<float64>::signaling_NaN(), // raiseBy is not needed for this test, unless you also want to test the derivative
+          4.5, false, true
         };
         float64 w_r_rank1 = ExactCallD::facedOdds_raise_Geom_forTest(w_r_rank0, 1.0, 0.0 ,  0.31640625
                                                                      ,hypothetical1, 4,0);


### PR DESCRIPTION
so we can standardize the betting information needed for…

* ExactCallD::facedOdds_raise_Geom
* ExactCallD::dfacedOdds_dpot_GeomDEXF
* and especially `ExpectedCallD::RiskLoss` which we are hoping to eliminate safely

Once this is done, we can hopefully resolve
https://github.com/yuzisee/pokeroo/pull/61/