### PR TITLE
Strongly type via templates into `FoldStatsCdf` / `CallStatsCdf` / `CommunityStatsCdf`

### DIFF
--- a/holdem/appsrc/stratManual.cpp
+++ b/holdem/appsrc/stratManual.cpp
@@ -55,7 +55,7 @@ void ConsoleStrategy::SeeCommunity(const Hand& h, const int8 cardsInCommunity)
 	comBuf.AppendUnique(h);
 
 	#ifdef INFOASSIST_STRONG
-        CallCumulationD possibleHands;
+        CommunityStatsCdf possibleHands;
         StatResult rankPCT;
 
 	    CommunityPlus onlyCommunity;

--- a/holdem/src/callPrediction.cpp
+++ b/holdem/src/callPrediction.cpp
@@ -1503,7 +1503,7 @@ void OpponentHandOpportunity::query(const float64 betSize) {
                 // In that case, e_opp would be counter-productive. Let's consider callcumu or even rank here instead.
                 FG.waitLength.meanConv =
                 //(opponentsFacingThem > 1.0) ?
-                0
+                nullptr
                 //: &(fCore.callcumu)
                 ;
                 // ( 1 / (x+1) )  ^ (1/x)

--- a/holdem/src/callPrediction.h
+++ b/holdem/src/callPrediction.h
@@ -29,6 +29,7 @@
 #undef DEBUG_TRACE_DEXF
 
 #include "math_support.h"
+#include "inferentials.h"
 #include "callPredictionFunctions.h"
 #include "callSituation.h"
 
@@ -97,29 +98,25 @@ class ExactCallD : public IExf
         float64 *noRaiseChance_A;
         float64 *noRaiseChanceD_A;
 
+        template<typename T> float64 facedOdds_call_Geom(const ChipPositionState & cps, float64 humanbet, float64 n,  CallCumulationD<T, OppositionPerspective> * useMean) const;
+        template<typename T> float64 dfacedOdds_dbetSize_Geom(const ChipPositionState & cps, float64 humanbet, float64 dpot, float64 w, float64 n,  CallCumulationD<T, OppositionPerspective> * useMean) const;
 
-        float64 facedOdds_call_Geom(const ChipPositionState & cps, float64 humanbet, float64 n,  CallCumulationD * useMean) const;
-        float64 dfacedOdds_dbetSize_Geom(const ChipPositionState & cps, float64 humanbet, float64 dpot, float64 w, float64 n,  CallCumulationD * useMean) const;
-
-
-        float64 facedOdds_raise_Geom(const struct HypotheticalBet & hypothetical, float64 startingPoint, float64 n, CallCumulationD * useMean) const;
-        float64 dfacedOdds_dpot_GeomDEXF(const struct HypotheticalBet & hypothetical, float64 w, float64 opponents, float64 dexf, CallCumulationD * useMean) const;
-
+        template<typename T> float64 facedOdds_raise_Geom(const struct HypotheticalBet & hypothetical, float64 startingPoint, float64 n, CallCumulationD<T, OppositionPerspective> * useMean) const;
+        template<typename T> float64 dfacedOdds_dpot_GeomDEXF(const struct HypotheticalBet & hypothetical, float64 w, float64 opponents, float64 dexf, CallCumulationD<T, OppositionPerspective> * useMean) const;
 
         void query(const float64 betSize, const int32 callSteps);
     public:
 
     // By default, startingPoint == 0.0
     // When using this function for the purposes of nextNoRaise_A, you'll want to start at the previous value to avoid rounding errors.
-    static float64 facedOdds_raise_Geom_forTest(float64 startingPoint, float64 denom, float64 riskLoss, float64 avgBlind, const struct HypotheticalBet & hypotheticalRaise, float64 opponents, CallCumulationD * useMean);
-
+    template<typename T> static float64 facedOdds_raise_Geom_forTest(float64 startingPoint, float64 denom, float64 riskLoss, float64 avgBlind, const struct HypotheticalBet & hypotheticalRaise, float64 opponents, CallCumulationD<T, OppositionPerspective> * useMean);
 
 
     // CallCumulationD &choicecumu = statprob.core.callcumu;
     // CallCumulationD &raisecumu = statprob.core.foldcumu;
     //    ExactCallBluffD myDeterredCall(&tablestate, &choicecumu, &raisecumu);
     struct CoreProbabilities &fCore;
-    CallCumulationD * ed() const {
+    CommunityStatsCdf * ed() const {
         return &(fCore.callcumu);
     }
 #ifdef DEBUG_TRACE_EXACTCALL
@@ -174,7 +171,7 @@ class ExactCallBluffD
 {//NO ASSIGNMENT OPERATOR
     private:
 
-    float64 facedOdds_Algb(const ChipPositionState & cps, float64 bet,float64 opponents,  CallCumulationD * useMean) const;
+    template<typename T> float64 facedOdds_Algb(const ChipPositionState & cps, float64 bet,float64 opponents,  CallCumulationD<T, OppositionPerspective> * useMean) const;
     float64 facedOddsND_Algb(const ChipPositionState & cps, float64 bet, float64 dpot, float64 w, float64 n) const;
 
         //topTwoOfThree returns the average of the top two values {a,b,c} through the 7th parameter.
@@ -189,8 +186,8 @@ class ExactCallBluffD
 
         const ExpectedCallD * const tableinfo;
 
-        CallCumulationD &fFoldCumu; // when they know your hand
-        CallCumulationD &fCallCumu; // when they _don't_ know your hand
+        FoldStatsCdf &fFoldCumu; // when they know your hand
+        CommunityStatsCdf &fCallCumu; // when they _don't_ know your hand
     protected:
 
         float64 allFoldChance;
@@ -233,7 +230,7 @@ class ExactCallBluffD
 
                             virtual float64 pWinD(const float64 betSize);
 
-            static float64 RiskPrice(const ExpectedCallD &tableinfo, CallCumulationD * foldcumu_caching);
+            static float64 RiskPrice(const ExpectedCallD &tableinfo, FoldStatsCdf * foldcumu_caching);
 
             ~ExactCallBluffD();
 

--- a/holdem/src/callPredictionFunctions.cpp
+++ b/holdem/src/callPredictionFunctions.cpp
@@ -42,7 +42,9 @@ const FoldWaitLengthModel & FoldWaitLengthModel::operator= ( const FoldWaitLengt
 }
  */
 
-template<typename T1, typename T2> bool FoldWaitLengthModel<T1, T2>::operator== ( const FoldWaitLengthModel<T1, T2> & o ) const
+// This is used by `FoldGainModel::query` to determine whether we can return cached values vs. whether we need to recompute.
+// TODO(from joseph): Find a way to determine whether the cached values are stale or not...
+template<typename T1, typename T2> bool FoldWaitLengthModel<T1, T2>::has_same_inputs ( const FoldWaitLengthModel<T1, T2> & o ) const
 {
     return (
         (o.amountSacrificeVoluntary == amountSacrificeVoluntary)
@@ -53,8 +55,13 @@ template<typename T1, typename T2> bool FoldWaitLengthModel<T1, T2>::operator== 
         && (o.prevPot == prevPot)
         && (o.w == w)
         && (o.meanConv == meanConv)
+    );
+}
 
-        && (o.cacheRarity == cacheRarity)
+template<typename T1, typename T2> bool FoldWaitLengthModel<T1, T2>::has_same_cached_output_values ( const FoldWaitLengthModel<T1, T2> & o ) const
+{
+    return (
+         (o.cacheRarity == cacheRarity)
         && (o.lastdBetSizeN == lastdBetSizeN)
         && (o.lastRawPCT == lastRawPCT)
         && (o.cached_d_dbetSize == cached_d_dbetSize)
@@ -520,7 +527,7 @@ template<typename T1, typename T2> void FoldGainModel<T1, T2>::query( const floa
 
     if(     lastBetSize == betSize
          //&& last_dw_dbet == dw_dbet
-         && lastWaitLength == waitLength
+         && lastWaitLength.has_same_inputs(waitLength)
       )
     {
         return;

--- a/holdem/src/callPredictionFunctions.cpp
+++ b/holdem/src/callPredictionFunctions.cpp
@@ -27,9 +27,9 @@
 
 #undef INLINE_INTEGER_POWERS
 
-FoldGainModel::~FoldGainModel(){}
+template<typename T1, typename T2> FoldGainModel<T1, T2>::~FoldGainModel(){}
 
-FoldWaitLengthModel::~FoldWaitLengthModel(){}
+template<typename T1, typename T2> FoldWaitLengthModel<T1, T2>::~FoldWaitLengthModel(){}
 
 
 /*
@@ -46,7 +46,7 @@ const FoldWaitLengthModel & FoldWaitLengthModel::operator= ( const FoldWaitLengt
 }
  */
 
-bool FoldWaitLengthModel::operator== ( const FoldWaitLengthModel & o ) const
+template<typename T1, typename T2> bool FoldWaitLengthModel<T1, T2>::operator== ( const FoldWaitLengthModel<T1, T2> & o ) const
 {
     return (
         (o.amountSacrificeVoluntary == amountSacrificeVoluntary)
@@ -65,7 +65,7 @@ bool FoldWaitLengthModel::operator== ( const FoldWaitLengthModel & o ) const
     );
 }
 
-float64 FoldWaitLengthModel::getRawPCT(const float64 n) {
+template<typename T1, typename T2> float64 FoldWaitLengthModel<T1, T2>::getRawPCT(const float64 n) {
     const float64 opponentInstances = n * rarity(); // After waiting n hands, the opponent will put you in this situation opponentInstances times.
     // The winPCT you would have if you had the best hand you would wait for out of opponentInstances hands.
     const float64 rawPCT = ( opponentInstances < 1 ) ? 0 : lookup(1.0-1.0/(opponentInstances));
@@ -81,7 +81,7 @@ float64 FoldWaitLengthModel::getRawPCT(const float64 n) {
     return rawPCT;
 }
 
-float64 FoldWaitLengthModel::d_rawPCT_d_n(const float64 n, const float64 rawPCT) {
+template<typename T1, typename T2> float64 FoldWaitLengthModel<T1, T2>::d_rawPCT_d_n(const float64 n, const float64 rawPCT) {
     if (n < 1) {
         return 0.0;
     }
@@ -103,7 +103,7 @@ float64 FoldWaitLengthModel::d_rawPCT_d_n(const float64 n, const float64 rawPCT)
     }
 }
 
-float64 FoldWaitLengthModel::d_rawPCT_d_w(const float64 n, float64 rawPCT) {
+template<typename T1, typename T2> float64 FoldWaitLengthModel<T1, T2>::d_rawPCT_d_w(const float64 n, float64 rawPCT) {
 
     const float64 opponentInstances = n * rarity();
     // rawPCT = lookup(1.0-1.0/(opponentInstances))
@@ -133,7 +133,7 @@ float64 FoldWaitLengthModel::d_rawPCT_d_w(const float64 n, float64 rawPCT) {
 // Your EV (win - loss) as a fraction, based on expected winPCT of the 1.0 - 1.0/n rank hand.
 // Return value is between -1.0 and +1.0
 // Will memoize while searching
-float64 FoldWaitLengthModel::d_dbetSize( const float64 n )
+template<typename T1, typename T2> float64 FoldWaitLengthModel<T1, T2>::d_dbetSize( const float64 n )
 {
 
 
@@ -175,7 +175,7 @@ float64 FoldWaitLengthModel::d_dbetSize( const float64 n )
 }
 
 
-float64 FoldWaitLengthModel::d_dw( const float64 n )
+template<typename T1, typename T2> float64 FoldWaitLengthModel<T1, T2>::d_dw( const float64 n )
 {
 
     // d_dw PW =             d_dw { 2 * pow(getRawPCT, opponents) - 1 }
@@ -228,7 +228,7 @@ float64 FoldWaitLengthModel::d_dw( const float64 n )
 
 // This is the derivative of f() with respect to amountSacrifice
 // For now it's only used as heuristic, so assume grossSacrifice is the only user of amountSacrifice.
-float64 FoldWaitLengthModel::d_dC( const float64 n )
+template<typename T1, typename T2> float64 FoldWaitLengthModel<T1, T2>::d_dC( const float64 n )
 {
     const float64 chanceOfFoldEachHand = rarity();
     const float64 chanceOfSameSituationFoldEachHand = chanceOfFoldEachHand * chanceOfFoldEachHand;
@@ -237,7 +237,7 @@ float64 FoldWaitLengthModel::d_dC( const float64 n )
 
 // See {const float64 remainingbet = ( bankroll - grossSacrifice(n)  );} in f()
 // This is the derivative of that expression with respect to n
-float64 FoldWaitLengthModel::dRemainingBet_dn( )
+template<typename T1, typename T2> float64 FoldWaitLengthModel<T1, T2>::dRemainingBet_dn( )
 {
     const float64 chanceOfFoldEachHand = rarity();
     const float64 chanceOfSameSituationFoldEachHand = chanceOfFoldEachHand * chanceOfFoldEachHand;
@@ -245,7 +245,7 @@ float64 FoldWaitLengthModel::dRemainingBet_dn( )
 }
 
 
-float64 FoldWaitLengthModel::grossSacrifice( const float64 n )
+template<typename T1, typename T2> float64 FoldWaitLengthModel<T1, T2>::grossSacrifice( const float64 n )
 {
 
     const float64 numHandsPerFold = 1.0 / rarity();
@@ -262,7 +262,7 @@ float64 FoldWaitLengthModel::grossSacrifice( const float64 n )
 // NOTE: this->meanConv if specified must be the view of the player who is choosing whether to fold.
 // When predicting opponent folds, it must be core.foldcumu
 // When evaluating your own folds, it must be core.handcumu
-float64 FoldWaitLengthModel::rarity( )
+template<typename T1, typename T2> float64 FoldWaitLengthModel<T1, T2>::rarity( )
 {
 
 #ifdef DEBUGASSERT
@@ -286,20 +286,20 @@ float64 FoldWaitLengthModel::rarity( )
     return cacheRarity;
 }
 
-float64 FoldWaitLengthModel::lookup( const float64 rank ) const
+template<typename T1, typename T2> float64 FoldWaitLengthModel<T1, T2>::lookup( const float64 rank ) const
 {
     if( meanConv == 0 ) return rank;
     return meanConv->nearest_winPCT_given_rank(rank);
 }
 
-float64 FoldWaitLengthModel::dlookup( const float64 rank, const float64 lookupped ) const
+template<typename T1, typename T2> float64 FoldWaitLengthModel<T1, T2>::dlookup( const float64 rank, const float64 lookupped ) const
 {
     if( meanConv == 0 ) return 1;
     return meanConv->inverseD(rank, lookupped);
 }
 
 //Maximizing this function gives you the best length that you want to wait for a fold for
-float64 FoldWaitLengthModel::f( const float64 n )
+template<typename T1, typename T2> float64 FoldWaitLengthModel<T1, T2>::f( const float64 n )
 {
 #ifdef DEBUGASSERT
     if(amountSacrificeVoluntary < 0.0)
@@ -369,7 +369,7 @@ float64 FoldWaitLengthModel::f( const float64 n )
 // When is it better to fold? When:
 // rarity > 1.0 / n
 // rarity > ...
-float64 FoldWaitLengthModel::fd( const float64 n, const float64 y )
+template<typename T1, typename T2> float64 FoldWaitLengthModel<T1, T2>::fd( const float64 n, const float64 y )
 {
     const float64 remainingbet = ( bankroll - grossSacrifice(n)  );
     if(remainingbet < 0)
@@ -413,7 +413,7 @@ float64 FoldWaitLengthModel::fd( const float64 n, const float64 y )
 }
 
 
-float64 FoldWaitLengthModel::FindBestLength()
+template<typename T1, typename T2> float64 FoldWaitLengthModel<T1, T2>::FindBestLength()
 {
     cacheRarity = -1;
     lastdBetSizeN = -1;
@@ -496,7 +496,7 @@ float64 FoldWaitLengthModel::FindBestLength()
     return bestN;
 }
 
-void FoldWaitLengthModel::load(const ChipPositionState &cps, float64 avgBlind) {
+template<typename T1, typename T2> void FoldWaitLengthModel<T1, T2>::load(const ChipPositionState &cps, float64 avgBlind) {
 #ifdef SACRIFICE_COMMITTED
     amountSacrificeForced = avgBlind;
     setAmountSacrificeVoluntary(cps.alreadyContributed + cps.alreadyBet
@@ -510,19 +510,17 @@ void FoldWaitLengthModel::load(const ChipPositionState &cps, float64 avgBlind) {
 }
 
 // Rarity depends on cached_d_dBetSize, so we have to clear the cache if we are updating w
-void FoldWaitLengthModel::setW(float64 neww) {
+template<typename T1, typename T2> void FoldWaitLengthModel<T1, T2>::setW(float64 neww) {
     cacheRarity = std::numeric_limits<float64>::signaling_NaN();
     w = neww;
 }
 
-float64 FoldWaitLengthModel::getW() const {
+template<typename T1, typename T2> float64 FoldWaitLengthModel<T1, T2>::getW() const {
     return w;
 }
 
-
-void FoldGainModel::query( const float64 betSize )
+template<typename T1, typename T2> void FoldGainModel<T1, T2>::query( const float64 betSize )
 {
-
 
     if(     lastBetSize == betSize
          //&& last_dw_dbet == dw_dbet
@@ -642,27 +640,27 @@ void FoldGainModel::query( const float64 betSize )
 #endif // DEBUGASSERT
 }
 
-float64 FoldGainModel::F_a( const float64 betSize ) {   query(betSize);return lastFA;   }
+template<typename T1, typename T2> float64 FoldGainModel<T1, T2>::F_a( const float64 betSize ) {   query(betSize);return lastFA;   }
 
 // Given a fixed number of hands to wait, this is FoldWaitLengthModel's d_dbetsize, a.k.a. winnings fraction.
-float64 FoldGainModel::F_b( const float64 betSize ) {   query(betSize);return lastFB;   }
+template<typename T1, typename T2> float64 FoldGainModel<T1, T2>::F_b( const float64 betSize ) {   query(betSize);return lastFB;   }
 
-float64 FoldGainModel::dF_dAmountSacrifice( const float64 betSize) {    query(betSize);return lastFC;   }
+template<typename T1, typename T2> float64 FoldGainModel<T1, T2>::dF_dAmountSacrifice( const float64 betSize) {    query(betSize);return lastFC;   }
 
-float64 FoldGainModel::f( const float64 betSize )
+template<typename T1, typename T2> float64 FoldGainModel<T1, T2>::f( const float64 betSize )
 {
     query(betSize);
     return lastf;
 
 }
 
-float64 FoldGainModel::fd( const float64 betSize, const float64 y )
+template<typename T1, typename T2> float64 FoldGainModel<T1, T2>::fd( const float64 betSize, const float64 y )
 {
     query(betSize);
     return lastfd;
 }
 
-void FacedOddsCallGeom::query( const float64 w )
+template<typename T> void FacedOddsCallGeom<T>::query( const float64 w )
 {
     if( lastW == w ) return;
     lastW = w;
@@ -686,20 +684,19 @@ void FacedOddsCallGeom::query( const float64 w )
 
 }
 
-float64 FacedOddsCallGeom::f( const float64 w )
+template<typename T> float64 FacedOddsCallGeom<T>::f( const float64 w )
 {
     query(w);
     return lastF;
 }
 
-
-float64 FacedOddsCallGeom::fd( const float64 w, const float64 excessU )
+template<typename T> float64 FacedOddsCallGeom<T>::fd( const float64 w, const float64 excessU )
 {
     query(w);
     return lastFD;
 }
 
-void FacedOddsAlgb::query( const float64 w )
+template<typename T> void FacedOddsAlgb<T>::query( const float64 w )
 {
     if( lastW == w ) return;
     lastW = w;
@@ -747,8 +744,8 @@ void FacedOddsAlgb::query( const float64 w )
     }
 }
 
-float64 FacedOddsAlgb::f( const float64 w ) { query(w);  return lastF; }
-float64 FacedOddsAlgb::fd( const float64 w, const float64 excessU ) { query(w);  return lastFD; }
+template<typename T> float64 FacedOddsAlgb<T>::f( const float64 w ) { query(w);  return lastF; }
+template<typename T> float64 FacedOddsAlgb<T>::fd( const float64 w, const float64 excessU ) { query(w);  return lastFD; }
 
 // lastF = U - nonRaiseGain
 //       = std::pow(1 + pot/FG.waitLength.bankroll  , fw)*std::pow(1 - raiseTo/FG.waitLength.bankroll  , 1 - fw)   −   nonRaiseGain
@@ -756,7 +753,7 @@ float64 FacedOddsAlgb::fd( const float64 w, const float64 excessU ) { query(w); 
 //
 // If you haven't bet yet (i.e. bCheckPossible == true)
 // nonRaiseGain = 1 - riskLoss / FG.waitLength.bankroll
-void FacedOddsRaiseGeom::query( const float64 w )
+template<typename T> void FacedOddsRaiseGeom<T>::query( const float64 w )
 {
     if( lastW == w ) return;
     lastW = w;
@@ -821,5 +818,5 @@ void FacedOddsRaiseGeom::query( const float64 w )
 	}
 }
 
-float64 FacedOddsRaiseGeom::f( const float64 w ) { query(w);  return lastF; }
-float64 FacedOddsRaiseGeom::fd( const float64 w, const float64 excessU ) { query(w);  return lastFD; }
+template<typename T> float64 FacedOddsRaiseGeom<T>::f( const float64 w ) { query(w);  return lastF; }
+template<typename T> float64 FacedOddsRaiseGeom<T>::fd( const float64 w, const float64 excessU ) { query(w);  return lastFD; }

--- a/holdem/src/callPredictionFunctions.cpp
+++ b/holdem/src/callPredictionFunctions.cpp
@@ -20,17 +20,13 @@
 
 
 #include "callPredictionFunctions.h"
+#include "inferentials.h"
 #include "portability.h"
 
 #include <iostream>
 
 
 #undef INLINE_INTEGER_POWERS
-
-template<typename T1, typename T2> FoldGainModel<T1, T2>::~FoldGainModel(){}
-
-template<typename T1, typename T2> FoldWaitLengthModel<T1, T2>::~FoldWaitLengthModel(){}
-
 
 /*
 const FoldWaitLengthModel & FoldWaitLengthModel::operator= ( const FoldWaitLengthModel & o )
@@ -820,3 +816,10 @@ template<typename T> void FacedOddsRaiseGeom<T>::query( const float64 w )
 
 template<typename T> float64 FacedOddsRaiseGeom<T>::f( const float64 w ) { query(w);  return lastF; }
 template<typename T> float64 FacedOddsRaiseGeom<T>::fd( const float64 w, const float64 excessU ) { query(w);  return lastFD; }
+
+template<typename T1, typename T2> FoldGainModel<T1, T2>::~FoldGainModel(){}
+template<typename T1, typename T2> FoldWaitLengthModel<T1, T2>::~FoldWaitLengthModel(){}
+
+template class FoldWaitLengthModel<void, void>;
+template class FoldWaitLengthModel<void, OppositionPerspective>;
+template class FoldWaitLengthModel<PlayerStrategyPerspective, OppositionPerspective>;

--- a/holdem/src/callPredictionFunctions.h
+++ b/holdem/src/callPredictionFunctions.h
@@ -108,6 +108,7 @@ struct HypotheticalBet {
 }
 ;
 
+template<typename T1, typename T2>
 class FoldWaitLengthModel : public virtual ScalarFunctionModel
 {
     private:
@@ -143,7 +144,7 @@ class FoldWaitLengthModel : public virtual ScalarFunctionModel
     // Describe the hand they would be folding
     float64 w;                    // Set to RANK if meanConv is null. Set to MEAN_winpct if using *meanConv
 public:
-    CallCumulationD (* meanConv); // Set to null if using RANK for payout simulation
+    CallCumulationD<T1, T2> (* meanConv); // Set to null if using RANK for payout simulation
 
     // Describe the situation
     float64 amountSacrificeVoluntary;
@@ -234,10 +235,11 @@ public:
 // If it's an opponent against you that knows your hand, they use foldcumu.
 // If it's you, you use callcumu.
 // If it's an opponent that doesn't know your hand, you use callcumu.
+template<typename T1, typename T2>
 class FoldGainModel : public virtual ScalarFunctionModel
 {
     protected:
-    FoldWaitLengthModel lastWaitLength;
+    FoldWaitLengthModel<T1, T2> lastWaitLength; // cached version of `FoldWaitLengthModel waitLength` below
     float64 lastBetSize;
     float64 last_dw_dbet;
     float64 lastf;
@@ -254,7 +256,7 @@ class FoldGainModel : public virtual ScalarFunctionModel
 
 
 
-    FoldWaitLengthModel waitLength;
+    FoldWaitLengthModel<T1, T2> waitLength;
 
     FoldGainModel(float64 myQuantum) : ScalarFunctionModel(myQuantum)
             , lastWaitLength(), lastBetSize(-1), last_dw_dbet(0) //Cache variables
@@ -274,6 +276,7 @@ class FoldGainModel : public virtual ScalarFunctionModel
 ;
 
 //How much call can you pick up to your bet?
+template<typename T>
 class FacedOddsCallGeom : public virtual ScalarFunctionModel
 {
     protected:
@@ -289,7 +292,7 @@ class FacedOddsCallGeom : public virtual ScalarFunctionModel
     float64 opponents;
 
 
-    FoldGainModel FG;
+    FoldGainModel<T, OppositionPerspective> FG;
     FacedOddsCallGeom(float64 myQuantum) : ScalarFunctionModel(0.5/RAREST_HAND_CHANCE), lastW(-1), FG(myQuantum/2) {}
     virtual float64 f(const float64 w);
     virtual float64 fd(const float64 w, const float64 U);
@@ -297,6 +300,7 @@ class FacedOddsCallGeom : public virtual ScalarFunctionModel
 ;
 
 //Will everybody fold consecutively to your bet?
+template<typename T>
 class FacedOddsAlgb : public virtual ScalarFunctionModel
 {
     protected:
@@ -310,7 +314,7 @@ class FacedOddsAlgb : public virtual ScalarFunctionModel
     float64 betSize;
 
 
-    FoldGainModel FG;
+    FoldGainModel<T, OppositionPerspective> FG;
     FacedOddsAlgb(float64 myQuantum) : ScalarFunctionModel(0.5/RAREST_HAND_CHANCE), lastW(-1), FG(myQuantum/2) {}
     virtual float64 f(const float64 w);
     virtual float64 fd(const float64 w, const float64 U);
@@ -318,6 +322,7 @@ class FacedOddsAlgb : public virtual ScalarFunctionModel
 ;
 
 //How much/likely would they raise or reraise?
+template<typename T>
 class FacedOddsRaiseGeom : public virtual ScalarFunctionModel
 {
     protected:
@@ -334,7 +339,7 @@ class FacedOddsRaiseGeom : public virtual ScalarFunctionModel
 	float64 callIncrBase;
     bool bCheckPossible;
 
-    FoldGainModel FG;
+    FoldGainModel<T, OppositionPerspective> FG;
     FacedOddsRaiseGeom(float64 myQuantum) : ScalarFunctionModel(0.5/RAREST_HAND_CHANCE), lastW(-1), FG(myQuantum/2) {}
     virtual float64 f(const float64 w);
     virtual float64 fd(const float64 w, const float64 U);

--- a/holdem/src/callPredictionFunctions.h
+++ b/holdem/src/callPredictionFunctions.h
@@ -159,7 +159,7 @@ public:
     // NOTE: quantum is 1/3rd of a hand. We don't need more precision than that when evaluating f(n).
     FoldWaitLengthModel() : ScalarFunctionModel(1.0/3.0),
     cacheRarity(std::numeric_limits<float64>::signaling_NaN()), lastdBetSizeN(std::numeric_limits<float64>::signaling_NaN()), lastRawPCT(std::numeric_limits<float64>::signaling_NaN()), cached_d_dbetSize(std::numeric_limits<float64>::signaling_NaN()), bSearching(false),
-    w(std::numeric_limits<float64>::signaling_NaN()), meanConv(0), amountSacrificeVoluntary(std::numeric_limits<float64>::signaling_NaN()), amountSacrificeForced(std::numeric_limits<float64>::signaling_NaN()), bankroll(std::numeric_limits<float64>::signaling_NaN()), opponents(std::numeric_limits<float64>::signaling_NaN()), betSize(std::numeric_limits<float64>::signaling_NaN()), prevPot(std::numeric_limits<float64>::signaling_NaN())
+    w(std::numeric_limits<float64>::signaling_NaN()), meanConv(nullptr), amountSacrificeVoluntary(std::numeric_limits<float64>::signaling_NaN()), amountSacrificeForced(std::numeric_limits<float64>::signaling_NaN()), bankroll(std::numeric_limits<float64>::signaling_NaN()), opponents(std::numeric_limits<float64>::signaling_NaN()), betSize(std::numeric_limits<float64>::signaling_NaN()), prevPot(std::numeric_limits<float64>::signaling_NaN())
     {}
 
     /*
@@ -199,7 +199,9 @@ public:
       this->prevPot = o.prevPot;
     }
 
-    bool operator== ( const FoldWaitLengthModel & o ) const;
+    bool has_same_inputs ( const FoldWaitLengthModel & o ) const;
+    bool has_same_cached_output_values ( const FoldWaitLengthModel & o ) const;
+    bool operator== ( const FoldWaitLengthModel & o ) const = delete;
 
     virtual ~FoldWaitLengthModel();
 

--- a/holdem/src/callPredictionFunctions.h
+++ b/holdem/src/callPredictionFunctions.h
@@ -108,6 +108,8 @@ struct HypotheticalBet {
 }
 ;
 
+// [!WARNING]
+// This template is instantiated at the bottom of src/callPredictionFunctions.cpp to avoid linker errors
 template<typename T1, typename T2>
 class FoldWaitLengthModel : public virtual ScalarFunctionModel
 {
@@ -136,9 +138,6 @@ class FoldWaitLengthModel : public virtual ScalarFunctionModel
 
     float64 cached_d_dbetSize;
     bool bSearching;
-
-
-
 
 
     // Describe the hand they would be folding
@@ -225,7 +224,6 @@ public:
 
     float64 get_cached_d_dbetSize() const { return cached_d_dbetSize; }
 
-
 }
 ;
 
@@ -270,10 +268,9 @@ class FoldGainModel : public virtual ScalarFunctionModel
     virtual float64 F_a(const float64 betSize);
     virtual float64 F_b(const float64 betSize);
     virtual float64 dF_dAmountSacrifice(const float64 betSize);
-
-
 }
 ;
+template class FoldGainModel<void, void>;
 
 //How much call can you pick up to your bet?
 template<typename T>
@@ -298,6 +295,7 @@ class FacedOddsCallGeom : public virtual ScalarFunctionModel
     virtual float64 fd(const float64 w, const float64 U);
 }
 ;
+template class FacedOddsCallGeom<PlayerStrategyPerspective>;
 
 //Will everybody fold consecutively to your bet?
 template<typename T>
@@ -320,6 +318,8 @@ class FacedOddsAlgb : public virtual ScalarFunctionModel
     virtual float64 fd(const float64 w, const float64 U);
 }
 ;
+template class FacedOddsAlgb<PlayerStrategyPerspective>;
+template class FacedOddsAlgb<void>;
 
 //How much/likely would they raise or reraise?
 template<typename T>
@@ -345,5 +345,7 @@ class FacedOddsRaiseGeom : public virtual ScalarFunctionModel
     virtual float64 fd(const float64 w, const float64 U);
 }
 ;
+template class FacedOddsRaiseGeom<void>;
+template class FacedOddsRaiseGeom<PlayerStrategyPerspective>;
 
 #endif

--- a/holdem/src/callSituation.cpp
+++ b/holdem/src/callSituation.cpp
@@ -19,6 +19,7 @@
  ***************************************************************************/
 
 #include "callSituation.h"
+#include "inferentials.h"
 
 
 ExpectedCallD::~ExpectedCallD()
@@ -59,7 +60,7 @@ float64 FoldOrCall::foldGain(MeanOrRank meanOrRank, const float64 extra, const f
     const float64 playerCount = suggestPlayerCount(fTable).inclAllIn();
 
     const float64 avgBlind = fTable.GetBlindValues().OpportunityPerHand(fTable.NumberAtTable());
-    FoldGainModel FG(fTable.GetChipDenom()/2);
+    FoldGainModel<PlayerStrategyPerspective, OppositionPerspective> FG(fTable.GetChipDenom()/2);
 
     // CoreProbabilities & myOdds;
     // If using RANK for payout simulation:
@@ -77,7 +78,7 @@ float64 FoldOrCall::foldGain(MeanOrRank meanOrRank, const float64 extra, const f
             // One vote for: core.statmean.pct from statProbability constructor of ExpectedCallD
             break;
         case RANK:
-            FG.waitLength.meanConv = 0;
+            FG.waitLength.meanConv = EMPTY_DISTRIBUTION;
             FG.waitLength.setW( fCore.statRanking().pct ); //fCore.callcumu.Pr_haveWinPCT_orbetter(fCore.statmean.pct); // rankW; // When called with e is 0, what is the rank -- how do we get that from fCore?
             // One vote for: const float64 rarity3 = core.callcumu.Pr_haveWinPCT_orbetter(core.statmean.pct); from StatResultProbabilities::Process_FoldCallMean
 
@@ -244,7 +245,7 @@ const Player * ExpectedCallD::ViewPlayer() const {
 
 // DEPRECATED: Use OpponentHandOpportunity and CombinedStatResultsPessemistic instead.
 // TODO: Let's say riskLoss is a table metric. In that case, if you use mean it's callcumu always.
-float64 ExpectedCallD::RiskLoss(const struct HypotheticalBet & hypotheticalRaise, CallCumulationD * useMean, float64 * out_dPot) const
+template<typename T> float64 ExpectedCallD::RiskLoss(const struct HypotheticalBet & hypotheticalRaise, CallCumulationD<T, OppositionPerspective> * useMean, float64 * out_dPot) const
 {
     const float64 raiseTo = hypotheticalRaise.hypotheticalRaiseTo;
     const int8 N = handsDealt(); // This is the number of people they would have to beat in order to ultimately come back and win the hand on the time they choose to catch you.
@@ -252,7 +253,7 @@ float64 ExpectedCallD::RiskLoss(const struct HypotheticalBet & hypotheticalRaise
 
     const float64 avgBlind = table->GetBlindValues().OpportunityPerHand(N);
 
-    FoldGainModel FG(table->GetChipDenom()/2);
+    FoldGainModel<T, OppositionPerspective> FG(table->GetChipDenom()/2);
     FG.waitLength.meanConv = useMean;
 
     if(useMean == 0)

--- a/holdem/src/callSituation.cpp
+++ b/holdem/src/callSituation.cpp
@@ -296,6 +296,8 @@ template<typename T> float64 ExpectedCallD::RiskLoss(const struct HypotheticalBe
 
 	return riskLoss;
 }
+template float64 ExpectedCallD::RiskLoss<PlayerStrategyPerspective>(const struct HypotheticalBet &, CallCumulationD<PlayerStrategyPerspective, OppositionPerspective> *, float64 *) const;
+template float64 ExpectedCallD::RiskLoss<void>(const struct HypotheticalBet &, CallCumulationD<void, OppositionPerspective> *, float64 *) const;
 
 MeanOrRank FoldOrCall::suggestMeanOrRank() const {
     if (suggestPlayerCount(fTable).inclAllIn() > 2) {

--- a/holdem/src/callSituation.h
+++ b/holdem/src/callSituation.h
@@ -23,6 +23,7 @@
 
 #include "arena.h"
 #include "callPredictionFunctions.h"
+#include "inferentials.h"
 
 //#define DEBUG_EXFDEXF
 
@@ -76,7 +77,7 @@ public:
      * Since making a small bet does not allow an average opponent to profit via his/her opportunity cost of folding, your ``RiskLoss`` remains zero as long as your bet is suffciently small compared to an average opponent's opportunity.
      * The value returned by the RiskLoss function is used as a deterrent for raising too high.
      */
-    virtual float64 RiskLoss(const struct HypotheticalBet & hypotheticalRaise, CallCumulationD * useMean, float64 * out_dPot = 0) const;
+    template<typename T> float64 RiskLoss(const struct HypotheticalBet & hypotheticalRaise, CallCumulationD<T, OppositionPerspective> * useMean, float64 * out_dPot = 0) const;
     virtual float64 PushGain() const;
 
     virtual uint8 OppRaiseOpportunities(int8 oppID) const;

--- a/holdem/src/functionmodel.cpp
+++ b/holdem/src/functionmodel.cpp
@@ -22,6 +22,7 @@
 #include <float.h>
 
 #include "functionmodel.h"
+#include "inferentials.h"
 #include "portability.h"
 
 
@@ -71,7 +72,7 @@ fSplitOpponents(opponentHandOpportunity.fTable.NumberInHand().inclAllIn() - 1)
 {}
 
 
-static std::pair<struct NetStatResult, float64> againstBestXOpponents(CallCumulationD & fOppCumu, float64 fractionOfHandsToBeat, float64 fractionOfHandsToBeat_dbetSize, playernumber_t fSplitOpponents) {
+static std::pair<struct NetStatResult, float64> againstBestXOpponents(FoldStatsCdf & fOppCumu, float64 fractionOfHandsToBeat, float64 fractionOfHandsToBeat_dbetSize, playernumber_t fSplitOpponents) {
     std::pair<struct NetStatResult, float64> result;
 
     const std::pair<StatResult, float64> bestXOpponents = fOppCumu.bestXHands(fractionOfHandsToBeat);
@@ -373,12 +374,12 @@ static NetStatResult initMultiOpponent(playernumber_t difficultyOpponents, playe
     }
 }
 
-static NetStatResult initSingleOpponent(playernumber_t difficultyOpponents, playernumber_t showdownOpponents, CallCumulationD &foldcumu) {
+static NetStatResult initSingleOpponent(playernumber_t difficultyOpponents, playernumber_t showdownOpponents, FoldStatsCdf &foldcumu) {
     const float64 fractionOfHandsToBeat = 1.0 / difficultyOpponents;
     return againstBestXOpponents(foldcumu, fractionOfHandsToBeat, 0.0, showdownOpponents).first;
 }
 
-PureStatResultGeom::PureStatResultGeom(const StatResult mean, const StatResult rank, const CoarseCommunityHistogram &outcomes, CallCumulationD &foldcumu, const ExpectedCallD &tableinfo)
+PureStatResultGeom::PureStatResultGeom(const StatResult mean, const StatResult rank, const CoarseCommunityHistogram &outcomes, FoldStatsCdf &foldcumu, const ExpectedCallD &tableinfo)
 :
 fDifficultyOpponents(tableinfo.handStrengthOfRound())
 ,

--- a/holdem/src/functionmodel.h
+++ b/holdem/src/functionmodel.h
@@ -171,7 +171,7 @@ private:
     // Count the number of possible opponents, including hypothetical "fold and come back stronger" hands.
     // This accounts for the fact that if you make an overbet in a particular situation, opponents will find only to return to this same situation in the future but with a better hand.
     OpponentHandOpportunity & fOpposingHands; // All OPPONENT odds against ME.
-    CallCumulationD * const fFoldCumu; // OPPOSING hands (as faring against me)
+    FoldStatsCdf * const fFoldCumu; // OPPOSING hands (as faring against me)
 
     const playernumber_t fSplitOpponents;
 }
@@ -277,7 +277,7 @@ private:
     const struct NetStatResult fNet;
 
 public:
-    PureStatResultGeom(const StatResult mean, const StatResult rank, const CoarseCommunityHistogram &outcomes, CallCumulationD &foldcumu, const ExpectedCallD &tableinfo);
+    PureStatResultGeom(const StatResult mean, const StatResult rank, const CoarseCommunityHistogram &outcomes, FoldStatsCdf &foldcumu, const ExpectedCallD &tableinfo);
     virtual ~PureStatResultGeom() {}
 
     playernumber_t splitOpponents() const override final { return fShowdownOpponents; }

--- a/holdem/src/inferentials.cpp
+++ b/holdem/src/inferentials.cpp
@@ -167,25 +167,29 @@ CallCumulation::~CallCumulation()
 {
 }
 
-
-void CallCumulation::ReversePerspective()
+// Not to be confused with `StatResult.ReversedPerspective` which... TODO(from joseph): Shouldn't we call `StatResult.ReversedPerspective` from within here?
+FoldStatsCdf CoreProbabilities::ReversePerspective(const MatchupStatsCdf &source_cdf)
 {
+   FoldStatsCdf reversed_cdf;
+   reversed_cdf.cumulation = source_cdf.cumulation;
+
 //Originally, the incremental/marginal rank of hand #n is [n].repeated - [n-1].repeated
-    std::reverse(cumulation.begin(),cumulation.end());
+    std::reverse(reversed_cdf.cumulation.begin(),reversed_cdf.cumulation.end());
 //After reversing, you must calculate [n].repeated - [n+1].repeated
     vector<StatResult>::iterator target;
-    vector<StatResult>::iterator next_target = cumulation.begin();
+    vector<StatResult>::iterator next_target = reversed_cdf.cumulation.begin();
 
     (*next_target).pct = 1 - (*next_target).pct;
     (*next_target).wins = 1 - (*next_target).wins - (*next_target).splits;
     (*next_target).loss = 1 - (*next_target).loss - (*next_target).splits;
+    // TODO(from joseph): We can `next_target->ReversedPerspective()` right?
 
-    while( next_target != cumulation.end() )
+    while( next_target != reversed_cdf.cumulation.end() )
     {
         target = next_target;
         ++next_target;
 
-        if( next_target == cumulation.end() )
+        if( next_target == reversed_cdf.cumulation.end() )
         {
             (*target).repeated = 1;
             break;
@@ -200,12 +204,12 @@ void CallCumulation::ReversePerspective()
         }
     }
 
-
+    return reversed_cdf;
 
 }
 
 ///This function is the derivative of nearest_winPCT_given_rank by drank
-float64 CallCumulationD::inverseD(const float64 rank, const float64 mean) const
+template<typename T1, typename T2> float64 CallCumulationD<T1, T2>::inverseD(const float64 rank, const float64 mean) const
 {
     //f(x) = Pr_haveWinPCT_strictlyBetterThan(x-EPS), where f(x) is rarity, 1-f(x) is rank, x is winPCT
     //nearest_winPCT_given_rank(1 - Pr_haveWinPCT_strictlyBetterThan(x-EPS)) = x
@@ -260,7 +264,7 @@ float64 CallCumulation::nearest_winPCT_given_rank(const float64 rank_toHave)
     }
     if( rank_toHave < low_rank )
     {
-        return cumulation[0].pct; //.pct is toHave -- if you haven't ReversedPerspective then that's the pct of the first hand dealt. See the bottom of CallStats::Analyze()
+        return cumulation[0].pct; //.pct is toHave -- if you haven't ReversePerspective()/ReversedPerspective() yet then that's the pct of the first hand dealt. See the bottom of CallStats::Analyze()
     }
     if( rank_toHave > cumulation[high_index-1].repeated )
     {
@@ -372,7 +376,7 @@ float64 CallCumulation::nearest_winPCT_given_rank(const float64 rank_toHave)
 
 }
 
-float64 CallCumulationD::linearInterpolate(float64 x1, float64 y1, float64 x2, float64 y2, float64 x) const
+template<typename T1, typename T2> float64 CallCumulationD<T1, T2>::linearInterpolate(float64 x1, float64 y1, float64 x2, float64 y2, float64 x) const
 {
     return ((x-x1)*y2 + (x2-x)*y1)/(x2-x1);
 }
@@ -400,7 +404,7 @@ float64 CallCumulation::Pr_haveWinPCT_strictlyBetterThan(const float64 winPCT_to
 //.pct is YOUR chance to win if you have that outcome (in all cases, .pct is the genPCT() of that StatResult)
 //.repeated is the rank of that outcome (actually, of the next outcome better)
 //We return the "probability of having a worse hand" or "Pr{PCT < winpct_tohave}" but smoothly interpolated across the histogram.
-std::pair<float64, float64> CallCumulationD::Pr_haveWorsePCT_continuous(const float64 winPCT_toHave) const
+template<typename T1, typename T2> std::pair<float64, float64> CallCumulationD<T1, T2>::Pr_haveWorsePCT_continuous(const float64 winPCT_toHave) const
 {//However, we would like to piecewise linear interpolate, so the function is continuous.
     // This helps especially because the derivative is never zero anywhere, which won't confuse a solver.
 

--- a/holdem/src/inferentials.cpp
+++ b/holdem/src/inferentials.cpp
@@ -378,7 +378,11 @@ float64 CallCumulation::nearest_winPCT_given_rank(const float64 rank_toHave)
 
 template<typename T1, typename T2> float64 CallCumulationD<T1, T2>::linearInterpolate(float64 x1, float64 y1, float64 x2, float64 y2, float64 x) const
 {
+  if (std::fabs(x1 - x2) < std::numeric_limits<float64>::epsilon()) {
+    return (y1 + y2) / 2.0;
+  } else {
     return ((x-x1)*y2 + (x2-x)*y1)/(x2-x1);
+  }
 }
 
 ///This function returns the probability of having winPCT_toHave or better

--- a/holdem/src/inferentials.h
+++ b/holdem/src/inferentials.h
@@ -315,8 +315,6 @@ public:
 
     vector<StatResult> cumulation;
 
-    virtual void ReversePerspective();
-
 
 	virtual float64 Pr_haveWinPCT_strictlyBetterThan(const float64 w_toHave) const;
 	virtual float64 nearest_winPCT_given_rank(const float64 rank); // for now is not `const` because it caches the result
@@ -349,6 +347,13 @@ public:
 }
 ;
 
+struct PlayerStrategyPerspective {};
+struct OppositionPerspective {};
+
+// This is the differentiable version of CallCumulation.
+// It's also strongly typed via templates into FoldStatsCdf / CallStatsCDf / CommunityStatsCdf to prevent accidentally mixing up callcumu vs.foldcumu vs. handcumu within CoreProbabilities.
+//   (We've had one too many bugs that stems from mixing these up)
+template<typename IsPlayerStrategyPerspective, typename IsOppositionPerspective>
 class CallCumulationD : public virtual CallCumulation
 {
 private:
@@ -388,7 +393,11 @@ public:
 }
 ;
 
-class CallCumulationZero : public virtual CallCumulationD
+using MatchupStatsCdf = CallCumulationD<PlayerStrategyPerspective, void>;
+using FoldStatsCdf = CallCumulationD<void, OppositionPerspective>;
+using CommunityStatsCdf = CallCumulationD<PlayerStrategyPerspective, OppositionPerspective>;
+
+class CallCumulationZero : public virtual CallCumulationD<PlayerStrategyPerspective, OppositionPerspective>
 {
     virtual float64 pctWillCall(const float64 oddsFaced) const
     {return 0;}
@@ -397,7 +406,7 @@ class CallCumulationZero : public virtual CallCumulationD
 }
 ;
 
-class CallCumulationFlat : public virtual CallCumulationD
+class CallCumulationFlat : public virtual CallCumulationD<PlayerStrategyPerspective, OppositionPerspective>
 {
     virtual float64 pctWillCall(const float64 oddsFaced) const
     {return 1-oddsFaced;}
@@ -517,12 +526,16 @@ enum MeanOrRank {
 
 #define EPS_WIN_PCT (1.0 / 2118760.0 / 990.0)
 
+
+constexpr CallCumulationD<PlayerStrategyPerspective, OppositionPerspective> * EMPTY_DISTRIBUTION = nullptr;
+// ^^^ TODO(from joseph): Is this ever needed? Why not `CallCumulationFlat` instead, which I'm pretty sure is what they do in most cases
+
 struct CoreProbabilities {
     int8 playerID;
 
-    CallCumulationD handcumu; // CallStats (your odds of winning against each possible opponent)
-    CallCumulationD foldcumu; // CallStats, REVERSED PERSPECTIVE (each opposing hand's chance to win)
-    CallCumulationD callcumu; // CommunityCallStats (each hole cards' inherent probability of winning)
+    MatchupStatsCdf handcumu; // CallStats (your odds of winning against each possible opponent)
+    FoldStatsCdf foldcumu; // CallStats, REVERSED PERSPECTIVE (each opposing hand's chance to win)
+    CommunityStatsCdf callcumu; // CommunityCallStats (each hole cards' inherent probability of winning)
 	StatResult statmean; // (Your hole cards' current inherent probability of winning)
 
     CoreProbabilities() : playerID(-1) {}
@@ -565,6 +578,8 @@ struct CoreProbabilities {
     double getFractionOfOpponentsWhereMyWinrateIsAtLeast(double winrate) {
         return handcumu.Pr_haveWinPCT_strictlyBetterThan(winrate);
     }
+
+    static FoldStatsCdf ReversePerspective(const MatchupStatsCdf&);
 
     // TODO(from joseph_huang): Refactor this (or where it is used) to supply mean vs. rank when dealing with heads-up vs. multi-hand.
 }

--- a/holdem/src/inferentials.h
+++ b/holdem/src/inferentials.h
@@ -392,6 +392,9 @@ public:
 
 }
 ;
+template class CallCumulationD<PlayerStrategyPerspective, void>;
+template class CallCumulationD<void, OppositionPerspective>;
+template class CallCumulationD<PlayerStrategyPerspective, OppositionPerspective>;
 
 using MatchupStatsCdf = CallCumulationD<PlayerStrategyPerspective, void>;
 using FoldStatsCdf = CallCumulationD<void, OppositionPerspective>;

--- a/holdem/src/stratPosition.cpp
+++ b/holdem/src/stratPosition.cpp
@@ -21,6 +21,7 @@
 #include "stratPosition.h"
 #include "arena.h"
 #include "callPrediction.h"
+#include "inferentials.h"
 #include "stratFear.h"
 
 #include <math.h>
@@ -131,8 +132,7 @@ void PositionalStrategy::SeeCommunity(const Hand& h, const int8 cardsInCommunity
 
     ///Compute CallStats
     StatsManager::QueryDefense(statprob.core.handcumu,withCommunity,onlyCommunity,cardsInCommunity);
-    statprob.core.foldcumu = statprob.core.handcumu;
-    statprob.core.foldcumu.ReversePerspective();
+    statprob.core.foldcumu = CoreProbabilities::ReversePerspective(statprob.core.handcumu);
 
     ///Compute CommunityCallStats
     ViewTable().CachedQueryOffense(statprob.core.callcumu,onlyCommunity, withCommunity);
@@ -301,7 +301,7 @@ void PositionalStrategy::setupPosition()
 
 }
 
-float64 PositionalStrategy::solveGainModel(HoldemFunctionModel* targetModel, CallCumulationD* const e)
+float64 PositionalStrategy::solveGainModel(HoldemFunctionModel* targetModel)
 {
 
 #if defined(DEBUG_GAIN) && defined(DEBUG_SINGLE_HAND)
@@ -444,7 +444,7 @@ void PositionalStrategy::printCommon(const ExpectedCallD &tablestate) {
 
 
 
-void PositionalStrategy::printFoldGain(float64 raiseGain, CallCumulationD * e, ExpectedCallD & estat) {
+void PositionalStrategy::printFoldGain(float64 raiseGain, CommunityStatsCdf * e, ExpectedCallD & estat) {
 #ifdef LOGPOSITION
     FoldOrCall foldGainCalculator(ViewTable(), statprob.core);
     std::pair<float64, float64> foldgainVal_xw = foldGainCalculator.myFoldGainAndWaitlength(foldGainCalculator.suggestMeanOrRank());
@@ -981,7 +981,7 @@ float64 ImproveGainStrategy::MakeBet()
 
 
 
-    const float64 bestBet = (bGamble == 0) ? solveGainModel(&choicemodel, &(statprob.core.callcumu)) : solveGainModel(&rolemodel, &(statprob.core.callcumu));
+    const float64 bestBet = (bGamble == 0) ? solveGainModel(&choicemodel) : solveGainModel(&rolemodel);
 
 #endif
 
@@ -1223,7 +1223,7 @@ float64 DeterredGainStrategy::MakeBet()
      }
      */
 
-    const float64 bestBet = solveGainModel(&choicemodel, &(statprob.core.callcumu));
+    const float64 bestBet = solveGainModel(&choicemodel);
 
 #ifdef LOGPOSITION
 
@@ -1458,7 +1458,7 @@ float64 PureGainStrategy::MakeBet()
     HoldemFunctionModel& choicemodel = ap_aggressive;
 
 
-    const float64 bestBet = solveGainModel(&choicemodel, &(statprob.core.callcumu));
+    const float64 bestBet = solveGainModel(&choicemodel);
 
 #ifdef LOGPOSITION
 

--- a/holdem/src/stratPosition.h
+++ b/holdem/src/stratPosition.h
@@ -26,6 +26,7 @@
 //#include "stratSearch.h"
 
 #include "debug_flags.h"
+#include "inferentials.h"
 
 
 
@@ -49,7 +50,7 @@ public:
         void printBetGradient(std::ofstream &logF, ExactCallD & opp_callraise, ExactCallBluffD & opp_fold, T & m, ExpectedCallD & tablestate, float64 separatorBet, CombinedStatResultsPessimistic * csrp) const;
         // ^^^ `.pRaise(…)` and `.pWin(…)` will update their respective caches, so it's not a *true* `const ExactCallD &` nor `const ExactCallBluffD &`
 
-        void printFoldGain(float64 raiseGain, CallCumulationD * e, ExpectedCallD & estat);
+        void printFoldGain(float64 raiseGain, CommunityStatsCdf * e, ExpectedCallD & estat);
 
 
 
@@ -75,7 +76,7 @@ public:
         void printCommon(const ExpectedCallD &tablestate);
 
         void setupPosition();
-        float64 solveGainModel(HoldemFunctionModel*, CallCumulationD* const e);
+        float64 solveGainModel(HoldemFunctionModel*);
 	public:
 
         void HardOpenLogFile();

--- a/holdem/unittests/main.cpp
+++ b/holdem/unittests/main.cpp
@@ -130,8 +130,7 @@ namespace UnitTests {
 
         ///Compute CallStats
         StatsManager::QueryDefense(statprob.core.handcumu,withCommunity,communityToTest,cardsInCommunity);
-        statprob.core.foldcumu = statprob.core.handcumu;
-        statprob.core.foldcumu.ReversePerspective();
+        statprob.core.foldcumu = CoreProbabilities::ReversePerspective(statprob.core.handcumu);
 
         ///Compute CommunityCallStats
         StatsManager::QueryOffense(statprob.core.callcumu,withCommunity,communityToTest,cardsInCommunity,0);
@@ -445,8 +444,7 @@ namespace UnitTests {
 
         ///Compute CallStats
         StatsManager::QueryDefense(statprob.core.handcumu,withCommunity,communityToTest,cardsInCommunity);
-        statprob.core.foldcumu = statprob.core.handcumu;
-        statprob.core.foldcumu.ReversePerspective();
+        statprob.core.foldcumu = CoreProbabilities::ReversePerspective(statprob.core.handcumu);
 
         ///Compute CommunityCallStats
         StatsManager::QueryOffense(statprob.core.callcumu,withCommunity,communityToTest,cardsInCommunity,0);
@@ -457,7 +455,7 @@ namespace UnitTests {
         statprob.core.playerID = 0;
         statprob.core.statmean = detailPCT.mean;
 
-        FoldWaitLengthModel fw;
+        FoldWaitLengthModel<void, OppositionPerspective> fw;
         // From the opponent's point of view if he knows he's against a flush
         fw.setW( 0.0 ); // Their current hand does not pair the board so loses to an ace-high flush (but note there is a ~30% chance that they hit a pair other than a deuce and a ~4% chance of having one deuce)
         fw.meanConv = &(statprob.core.foldcumu);
@@ -494,10 +492,10 @@ namespace UnitTests {
         const float64 iveBeenReraisedTo = 190.0;
 
 
-        FoldWaitLengthModel fw;
+        FoldWaitLengthModel<void, void> fw;
 
         fw.setW( 0.75 ); // You have a decent hand, but it could be better and the re-raise was ridiculously enormous.
-        fw.meanConv = 0;
+        fw.meanConv = nullptr;
         fw.amountSacrificeForced = avgBlind;
         fw.bankroll = 1000.0;
         fw.setAmountSacrificeVoluntary(myConstributionToPastPot + myBetThisRound - avgBlind);
@@ -560,10 +558,10 @@ namespace UnitTests {
         const float64 iveBeenReraisedTo = 5000.0;
 
 
-        FoldWaitLengthModel fw;
+        FoldWaitLengthModel<void, void> fw;
 
         fw.setW(0.75); // You have a decent hand, but it could be better and the raise was large.
-        fw.meanConv = 0;
+        fw.meanConv = nullptr;
         fw.amountSacrificeForced = avgBlind;
         fw.bankroll = 10000.0;
         fw.setAmountSacrificeVoluntary(myConstributionToPastPot + myBetThisRound - avgBlind);
@@ -644,8 +642,7 @@ namespace UnitTests {
 
         ///Compute CallStats
         StatsManager::QueryDefense(statprob.core.handcumu,withCommunity,communityToTest,cardsInCommunity);
-        statprob.core.foldcumu = statprob.core.handcumu;
-        statprob.core.foldcumu.ReversePerspective();
+        statprob.core.foldcumu = CoreProbabilities::ReversePerspective(statprob.core.handcumu);
 
         ///Compute CommunityCallStats
         StatsManager::QueryOffense(statprob.core.callcumu,withCommunity,communityToTest,cardsInCommunity,0);
@@ -708,8 +705,7 @@ namespace UnitTests {
 
         ///Compute CallStats
         StatsManager::QueryDefense(statprob.core.handcumu,withCommunity,communityToTest,cardsInCommunity);
-        statprob.core.foldcumu = statprob.core.handcumu;
-        statprob.core.foldcumu.ReversePerspective();
+        statprob.core.foldcumu = CoreProbabilities::ReversePerspective(statprob.core.handcumu);
 
         ///Compute CommunityCallStats
         StatsManager::QueryOffense(statprob.core.callcumu,withCommunity,communityToTest,cardsInCommunity,0);
@@ -768,9 +764,7 @@ namespace UnitTests {
 
         ///Compute CallStats
         StatsManager::QueryDefense(statprob.core.handcumu,withCommunity,communityToTest,cardsInCommunity);
-        statprob.core.foldcumu = statprob.core.handcumu;
-        statprob.core.foldcumu.ReversePerspective();
-
+        statprob.core.foldcumu = CoreProbabilities::ReversePerspective(statprob.core.handcumu);
 
         // TEST:
         const float64 xa = 0.3;
@@ -855,8 +849,7 @@ namespace UnitTests {
 
         ///Compute CallStats
         StatsManager::QueryDefense(statprob.core.handcumu,withCommunity,communityToTest,cardsInCommunity);
-        statprob.core.foldcumu = statprob.core.handcumu;
-        statprob.core.foldcumu.ReversePerspective();
+        statprob.core.foldcumu = CoreProbabilities::ReversePerspective(statprob.core.handcumu);
 
         ///Compute CommunityCallStats
         StatsManager::QueryOffense(statprob.core.callcumu,withCommunity,communityToTest,cardsInCommunity,0);
@@ -885,8 +878,8 @@ namespace UnitTests {
           std::numeric_limits<float64>::signaling_NaN(), // raiseBy is not needed for this test, unless you also want to test the derivative
           4.5, false, true
         };
-        float64 w_r_rank0 = ExactCallD::facedOdds_raise_Geom_forTest(0.0, 1.0 /* denom */, 0.0 /* RiskLoss */ , 0.31640625 /* avgBlind */
-                                                                     ,hypothetical0, 4,0);
+        float64 w_r_rank0 = ExactCallD::facedOdds_raise_Geom_forTest<void>(0.0, 1.0 /* denom */, 0.0 /* RiskLoss */ , 0.31640625 /* avgBlind */
+                                                                     ,hypothetical0, 4, nullptr);
         // tableinfo->RiskLoss(0, 2474, 4, 11.25, 0, 0) == 0.0
         HypotheticalBet hypothetical1 = {
           oppCPS,
@@ -894,8 +887,8 @@ namespace UnitTests {
           std::numeric_limits<float64>::signaling_NaN(), // raiseBy is not needed for this test, unless you also want to test the derivative
           4.5, false, true
         };
-        float64 w_r_rank1 = ExactCallD::facedOdds_raise_Geom_forTest(w_r_rank0, 1.0, 0.0 ,  0.31640625
-                                                                     ,hypothetical1, 4,0);
+        float64 w_r_rank1 = ExactCallD::facedOdds_raise_Geom_forTest<void>(w_r_rank0, 1.0, 0.0 ,  0.31640625
+                                                                     ,hypothetical1, 4, nullptr);
 
         // The bug is: These two values, if otherwise equal, can end up being within half-quantum.
         assert(w_r_rank0 <= w_r_rank1);
@@ -3747,8 +3740,7 @@ namespace RegressionTests {
 
         ///Compute CallStats
         StatsManager::QueryDefense(statprob.core.handcumu,withCommunity,communityToTest,cardsInCommunity);
-        statprob.core.foldcumu = statprob.core.handcumu;
-        statprob.core.foldcumu.ReversePerspective();
+        statprob.core.foldcumu = CoreProbabilities::ReversePerspective(statprob.core.handcumu);
 
         ///Compute CommunityCallStats
         StatsManager::QueryOffense(statprob.core.callcumu,withCommunity,communityToTest,cardsInCommunity,0);
@@ -4285,8 +4277,7 @@ namespace RegressionTests {
 
         ///Compute CallStats
         StatsManager::QueryDefense(statprob.core.handcumu,withCommunity,community,5);
-        statprob.core.foldcumu = statprob.core.handcumu;
-        statprob.core.foldcumu.ReversePerspective();
+        statprob.core.foldcumu = CoreProbabilities::ReversePerspective(statprob.core.handcumu);
 
         ///Compute CommunityCallStats
         StatsManager::QueryOffense(statprob.core.callcumu,withCommunity,community,5,0);
@@ -4300,10 +4291,10 @@ namespace RegressionTests {
 
         const float64 opponentsFacingThem = 1.0;
 
-        FoldWaitLengthModel waitLength;
+        FoldWaitLengthModel<void, void> waitLength;
         waitLength.meanConv =
         //(opponentsFacingThem > 1.0) ?
-        0
+        nullptr
         //: &(fCore.callcumu)
         ;
         // ( 1 / (x+1) )  ^ (1/x)
@@ -4463,8 +4454,7 @@ namespace RegressionTests {
 
         ///Compute CallStats
         StatsManager::QueryDefense(statprob.core.handcumu,withCommunity,communityToTest,cardsInCommunity);
-        statprob.core.foldcumu = statprob.core.handcumu;
-        statprob.core.foldcumu.ReversePerspective();
+        statprob.core.foldcumu = CoreProbabilities::ReversePerspective(statprob.core.handcumu);
 
         ///Compute CommunityCallStats
         StatsManager::QueryOffense(statprob.core.callcumu,withCommunity,communityToTest,cardsInCommunity,0);

--- a/holdem/unittests/regenerate_opening_book.cpp
+++ b/holdem/unittests/regenerate_opening_book.cpp
@@ -41,7 +41,7 @@ static string spotCheckDb(const struct DeckLocationPair &holeCards, char fileSuf
                 std::cout.flush(); // Flush for timestamping
 
             // struct CoreProbabilities statprob_core;
-            CallCumulationD statprob_core_handcumu;
+            MatchupStatsCdf statprob_core_handcumu;
             ///Compute CallStats
             StatsManager::QueryDefense(statprob_core_handcumu,withCommunity,CommunityPlus::EMPTY_COMPLUS,cardsInCommunity);
 


### PR DESCRIPTION
The goal is to prevent accidentally mixing up callcumu vs.foldcumu vs. handcumu within CoreProbabilities.

(We've had one too many bugs that stems from mixing these up)

Once this is merged, it will help us on the debugging of https://github.com/yuzisee/pokeroo/pull/44