### PR TITLE
Add a basic system test

### DIFF
--- a/holdem/Makefile
+++ b/holdem/Makefile
@@ -57,7 +57,8 @@ test:
 	date
 	g++ $(CXXFLAGS) -D RTTIASSERT -O3 -o bin/unittests_gcc_O3 -Isrc $(wildcard src/*.cpp) unittests/main.cpp
 	echo ~/pokeroo-run/lib/holdemdb/ > unittests/holdemdb.ini
-	cd unittests && ../bin/unittests_clang && ../bin/unittests_gcc_O3
+	mkdir -p /tmp/code_coverage.llvm
+	cd unittests && LLVM_PROFILE_FILE="/tmp/code_coverage.llvm/unittests.profraw" sh test_harness.sh ../bin/unittests_clang && sh test_harness.sh ../bin/unittests_gcc_O3
 
 # `-fno-exceptions -fno-rtti` maybe?
 db:

--- a/holdem/unittests/playlogs.expected/11.txt
+++ b/holdem/unittests/playlogs.expected/11.txt
@@ -1,0 +1,54 @@
+
+==========#11==========
+Playing as ~
+*
+(M) 58.1347%
+(M.w) 56.9062%
+(M.s) 2.45692%
+(M.l) 40.6369%
+(Better All-in) 65.4286%
+(Re.s) 0.244898%
+(Better Mean Rank) 81.1837%
+(Ra.s) 0.571429%
+
+*
+Jh Qd Bet to call 10 (from 5) at 25 pot, 
+Community outcomes (stdev = 0.178195 pcts , avgdev = 0.158877 pcts ), kurtosis = -1.27061
+0.270373 pct: least helpful community
+0.349659 pct: 1305 / 19600 (6.65816%)
+0.431609 pct: 7212 / 19600 (36.7959%)
+0.528326 pct: 3295 / 19600 (16.8112%)
+0.581347 pct (mean): mean- 0.600459   mean+ 0.399541 (skew 0.459758 tail right) 
+0.618214 pct: 1386 / 19600 (7.07143%)
+0.771736 pct: 1769 / 19600 (9.02551%)
+0.818028 pct: 4043 / 19600 (20.6276%)
+0.940948 pct: 590 / 19600 (3.0102%)
+0.999955 pct: most helpful community
+CallStrength W(2r)=0.426489 L=0.570306 o.w_s=(0.653061,0.00244898)
+(MinRaise to $20) 	W(2x)=0.459014 L=0.519155 2o.w_s=(0.578635,0.0135998)
+ -  statrelation geom RAW - 
+9 dealt, 8 opp. (round), 2 opp. assumed str., 2 opp. still in
+Choice Optimal 10
+Choice Fold 10
+f(10)=0.996865
+CHECK/FOLD
+FoldGain()R=0.999074 x 0(=0 folds)	vs play:0.995939   ->assumes $5 forced
+ AgainstCall(10)=1.00058 from +$2.82672 @ 0.305634
+AgainstRaise(10)=0.995366 from -$10 @ 0.694366
+        Push(10)=1 from $0 @ 0
+ AgainstCall(20)=1.00081 from +$4.34407 @ 0.27984
+AgainstRaise(20)=0.99038 from -$20 @ 0.72016
+        Push(20)=1 from $0 @ 0
+OppRAISEChanceR [*] 0.169246 @ $20 ($10 now)	fold -- 0	W(2x)=0.459014 L=0.519155 2o.w_s=(0.578635,0.0135998)
+OppRAISEChanceR [F] 0.694366 @ $30 ($10 now)	fold -- 0.0281866	W(8.3615x)=0.318911 L=0.67072 2o.w_s=(0.529247,0.00853524)
+OppRAISEChanceR [F] 0.553711 @ $50 ($0 now)	fold -- 0.100314	W(9.79594x)=0.302997 L=0.685773 2o.w_s=(0.522228,0.00958921)
+OppRAISEChanceR [F] 0.374409 @ $90 ($12.9536 now)	fold -- 0.325489	W(17.2803x)=0.236531 L=0.747804 2o.w_s=(0.489156,0.0159383)
+OppRAISEChanceR [F] 0.230201 @ $170 ($16.437 now)	fold -- 0.462417	W(22.4468x)=0.218145 L=0.765014 2o.w_s=(0.478736,0.0181368)
+OppRAISEChanceR [F] 0.124457 @ $330 ($21.2636 now)	fold -- 0.577168	W(29.5402x)=0.20532 L=0.778226 2o.w_s=(0.471376,0.0185231)
+OppRAISEChanceR [F] 0.0579688 @ $650 ($25.3887 now)	fold -- 0.695675	W(40.5625x)=0.188441 L=0.796569 2o.w_s=(0.461406,0.0180011)
+OppRAISEChanceR [F] 0.0173633 @ $1290 ($30.7344 now)	fold -- 0.749976	W(55.7709x)=0.166513 L=0.821277 2o.w_s=(0.447684,0.0161227)
+OppRAISEChanceR [F] 0 @ $1500 ($31.9083 now)	fold -- 0.717866	W(42.7396x)=0.18508 L=0.799956 2o.w_s=(0.459265,0.0182056)
+
+(Fixed at $10)	W(2x)=0.459014 L=0.519155 2o.w_s=(0.578635,0.0135998)
+Guaranteed > $0 is in the pot for sure
+OppFoldChance% ...    0   d\0

--- a/holdem/unittests/playlogs.expected/12.txt
+++ b/holdem/unittests/playlogs.expected/12.txt
@@ -1,0 +1,202 @@
+
+==========#11==========
+Playing as ~
+*
+(M) 62.7217%
+(M.w) 61.5681%
+(M.s) 2.30714%
+(M.l) 36.1248%
+(Better All-in) 90.7347%
+(Re.s) 0.244898%
+(Better Mean Rank) 92.1224%
+(Ra.s) 0.571429%
+
+*
+Ts Ah Bet to call 10 (from 0) at 15 pot, 
+Community outcomes (stdev = 0.145217 pcts , avgdev = 0.12647 pcts ), kurtosis = -0.95513
+0.340367 pct: least helpful community
+0.414247 pct: 449 / 19600 (2.29082%)
+0.501275 pct: 6988 / 19600 (35.6531%)
+0.576343 pct: 5180 / 19600 (26.4286%)
+0.627217 pct (mean): mean- 0.647551   mean+ 0.352449 (skew 0.660851 tail right) 
+0.668879 pct: 1076 / 19600 (5.4898%)
+0.773038 pct: 2282 / 19600 (11.6429%)
+0.851559 pct: 3065 / 19600 (15.6378%)
+0.937983 pct: 560 / 19600 (2.85714%)
+0.999972 pct: most helpful community
+CallStrength W(2r)=0.843399 L=0.146073 o.w_s=(0.918367,0.00571429)
+(MinRaise to $20) 	W(7.06789x)=0.401601 L=0.532568 2o.w_s=(0.552125,0.0435355)
+ -  stat_high algb SLIDERX - 
+9 dealt, 8 opp. (round), 2 opp. assumed str., 2 opp. still in
+Choice Optimal 10
+Choice Fold 15
+f(10)=1.11897
+CALL 10
+FoldGain()R=0.999074 x 0(=0 folds)	vs play:1.11804
+ AgainstCall(10)=1.00616 from +$13.1972 @ 0.700339
+AgainstRaise(10)=1.11188 from +$560.032 @ 0.299661
+        Push(10)=1 from $0 @ 0
+ AgainstCall(20)=1.00012 from +$0.367263 @ 0.471145
+AgainstRaise(20)=0.993531 from -$20 @ 0.485152
+        Push(20)=1.00048 from +$16.5982 @ 0.0437035
+OppRAISEChanceR [*] 0.299661 @ $20 ($10 now)	fold -- 0.0437035	W(7.06789x)=0.401601 L=0.532568 2o.w_s=(0.552125,0.0435355)
+OppRAISEChanceR [*] 0.297662 @ $30 ($10 now)	fold -- 0.112969	W(14.2584x)=0.305986 L=0.665384 2o.w_s=(0.519997,0.0237833)
+OppRAISEChanceR [*] 0.294003 @ $50 ($0 now)	fold -- 0.351572	W(17.1653x)=0.275843 L=0.690488 2o.w_s=(0.50502,0.0299336)
+OppRAISEChanceR [*] 0.287016 @ $90 ($12.9536 now)	fold -- 0.545517	W(21.7497x)=0.240719 L=0.718537 2o.w_s=(0.485521,0.0394833)
+OppRAISEChanceR [*] 0.276469 @ $170 ($16.437 now)	fold -- 0.648696	W(28.465x)=0.226455 L=0.721413 2o.w_s=(0.474999,0.0518442)
+OppRAISEChanceR [*] 0.253154 @ $330 ($21.2636 now)	fold -- 0.721074	W(38.2132x)=0.218307 L=0.729595 2o.w_s=(0.470244,0.0531115)
+OppRAISEChanceR [*] 0.214575 @ $650 ($25.3887 now)	fold -- 0.780957	W(52.3465x)=0.211044 L=0.73962 2o.w_s=(0.466525,0.0516684)
+OppRAISEChanceR [*] 0.124848 @ $1290 ($30.7344 now)	fold -- 0.820352	W(72.6629x)=0.202428 L=0.751763 2o.w_s=(0.462057,0.0496177)
+OppRAISEChanceR [*] 0 @ $1500 ($31.9083 now)	fold -- 0.809625	W(55.6304x)=0.209012 L=0.741422 2o.w_s=(0.46523,0.0522319)
+
+(Fixed at $10)	W(2x)=0.561519 L=0.416731 2o.w_s=(0.60919,0.0116866)
+Guaranteed > $0 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+4d 7h 9d community
+*
+(M) 49.0141%
+(M.w) 48.3481%
+(M.s) 1.33201%
+(M.l) 50.3199%
+(Better All-in) 53.1915%
+(Re.s) 0.370028%
+(Better Mean Rank) 53.0612%
+(Ra.s) 0%
+
+*
+Ts Ah Bet to call 0 (from 0) at 25 pot, 
+Community outcomes (stdev = 0.126756 pcts , avgdev = 0.091558 pcts ), kurtosis = 1.96178
+0.336605 pct: least helpful community
+0.377593 pct: 10 / 47 (21.2766%)
+0.438939 pct: 20 / 47 (42.5532%)
+0.490141 pct (mean): mean- 0.659574   mean+ 0.340426 (skew 1.64471 tail right) 
+0.524063 pct: 11 / 47 (23.4043%)
+0.599874 pct: 0 / 47 (0%)
+0.687923 pct: 1 / 47 (2.12766%)
+0.767662 pct: 3 / 47 (6.38298%)
+0.863142 pct: 2 / 47 (4.25532%)
+0.863142 pct: most helpful community
+CallStrength W(1m)=0.483481 L=0.503199 o.w_s=(0.483481,0.0133201)
+(MinRaise to $10) 	W(1x)=0.483481 L=0.503199 1o.w_s=(0.483481,0.0133201)
+ -  stat_high algb SLIDERX - 
+9 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 0
+Choice Fold 45
+f(0)=1.01487
+CALL 0
+FoldGain()M=0.993289 x 0(=0 folds)	vs play:1.00815
+ AgainstCall(0)=1.00815 from +$12.2535 @ 0.991597
+AgainstRaise(0)=1 from $0 @ 0.00840271
+        Push(0)=1 from $0 @ 0
+ AgainstCall(10)=0.999376 from +$12.0563 @ -0.0771787
+AgainstRaise(10)=0.994367 from -$10 @ 0.839261
+        Push(10)=1.00434 from +$27.1769 @ 0.237918
+OppRAISEChanceM [*] 0 @ $10 ($10 now)	fold -- 0.237918	W(1x)=0.483481 L=0.503199 1o.w_s=(0.483481,0.0133201)
+OppRAISEChanceM [*] 0 @ $20 ($10 now)	fold -- 0.392643	W(6.66667x)=0.12192 L=0.865914 1o.w_s=(0.12192,0.0121661)
+OppRAISEChanceM [*] 0 @ $40 ($11.4744 now)	fold -- 0.507814	W(7.83333x)=0.114017 L=0.874455 1o.w_s=(0.114017,0.0115283)
+OppRAISEChanceM [*] 0 @ $80 ($15.7323 now)	fold -- 0.551397	W(9.66667x)=0.105061 L=0.884136 1o.w_s=(0.105061,0.0108031)
+OppRAISEChanceM [*] 0 @ $160 ($21.1531 now)	fold -- 0.610157	W(12.5x)=0.0932727 L=0.896963 1o.w_s=(0.0932727,0.00976462)
+OppRAISEChanceM [*] 0 @ $320 ($28.5992 now)	fold -- 0.667853	W(16.6667x)=0.0791414 L=0.9135 1o.w_s=(0.0791414,0.00735882)
+OppRAISEChanceM [*] 0 @ $640 ($36.4064 now)	fold -- 0.725666	W(22.8333x)=0.0624735 L=0.935579 1o.w_s=(0.0624735,0.00194778)
+OppRAISEChanceM [F] 0.00840271 @ $1280 ($46.9694 now)	fold -- 0.746162	W(31.6667x)=0.0533768 L=0.946623 1o.w_s=(0.0533768,0)
+OppRAISEChanceM [F] 0 @ $1490 ($50.1358 now)	fold -- 0.645141	W(24.3333x)=0.0583887 L=0.93977 1o.w_s=(0.0583887,0.00184173)
+
+(Fixed at $0)	W(1x)=0.483481 L=0.503199 1o.w_s=(0.483481,0.0133201)
+Guaranteed > $25 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+4d 7h 9d Ad community
+*
+(M) 76.6315%
+(M.w) 76.3614%
+(M.s) 0.540184%
+(M.l) 23.0984%
+(Better All-in) 87.6329%
+(Re.s) 0.386473%
+(Better Mean Rank) 90.9574%
+(Ra.s) 0%
+
+*
+Ts Ah Bet to call 0 (from 0) at 25 pot, 
+Community outcomes (stdev = 0.126404 pcts , avgdev = 0.100506 pcts ), kurtosis = -0.183574
+0.510101 pct: least helpful community
+0.52716 pct: 9 / 46 (19.5652%)
+0.607071 pct: 1 / 46 (2.17391%)
+0.657468 pct: 0 / 46 (0%)
+0.716414 pct: 0 / 46 (0%)
+0.766315 pct (mean): (skew -1.15951 tail left) mean- 0.217391   mean+ 0.782609
+0.794949 pct: 9 / 46 (19.5652%)
+0.829425 pct: 23 / 46 (50%)
+0.916919 pct: 4 / 46 (8.69565%)
+0.922727 pct: most helpful community
+CallStrength W(1m)=0.763614 L=0.230984 o.w_s=(0.763614,0.00540184)
+(MinRaise to $10) 	W(1x)=0.763614 L=0.230984 1o.w_s=(0.763614,0.00540184)
+ -  stat_high algb SLIDERX - 
+9 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 0
+Choice Fold 120
+f(0)=1.01957
+CALL 0
+FoldGain()M=0.993289 x 0(=0 folds)	vs play:1.01286
+ AgainstCall(0)=1.01286 from +$19.1579 @ 1
+AgainstRaise(0)=1 from $0 @ 0
+        Push(0)=1 from $0 @ 0
+ AgainstCall(10)=1.00327 from +$24.4842 @ 0.198945
+AgainstRaise(10)=0.996574 from -$10 @ 0.510441
+        Push(10)=1.00519 from +$26.6154 @ 0.290614
+OppRAISEChanceM [*] 0 @ $10 ($10 now)	fold -- 0.290614	W(1x)=0.763614 L=0.230984 1o.w_s=(0.763614,0.00540184)
+OppRAISEChanceM [*] 0 @ $20 ($0 now)	fold -- 0.545907	W(6.66667x)=0.164324 L=0.799663 1o.w_s=(0.164324,0.0360123)
+OppRAISEChanceM [*] 0 @ $40 ($15.6155 now)	fold -- 0.663551	W(7.83333x)=0.0763212 L=0.881364 1o.w_s=(0.0763212,0.0423144)
+OppRAISEChanceM [*] 0 @ $80 ($23.7176 now)	fold -- 0.720012	W(9.66667x)=0.0510613 L=0.948939 1o.w_s=(0.0510613,1.11022e-16)
+OppRAISEChanceM [*] 0 @ $160 ($35.306 now)	fold -- 0.775816	W(12.5x)=0.0212451 L=0.978755 1o.w_s=(0.0212451,0)
+OppRAISEChanceM [*] 0 @ $320 ($51.7964 now)	fold -- 0.820759	W(16.6667x)=0.00559947 L=0.994401 1o.w_s=(0.00559947,0)
+OppRAISEChanceM [*] 0 @ $640 ($75.2992 now)	fold -- 0.864691	W(22.8333x)=0 L=1 1o.w_s=(0,0)
+OppRAISEChanceM [*] 0 @ $1280 ($109.464 now)	fold -- 0.892787	W(31.6667x)=0 L=1 1o.w_s=(0,0)
+OppRAISEChanceM [*] 0 @ $1490 ($118.956 now)	fold -- 0.871108	W(24.3333x)=0 L=1 1o.w_s=(0,0)
+
+(Fixed at $0)	W(1x)=0.763614 L=0.230984 1o.w_s=(0.763614,0.00540184)
+Guaranteed > $25 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+4d 7h 8h 9d Ad community
+*
+(M) 79.899%
+(M.w) 79.596%
+(M.s) 0.606061%
+(M.l) 19.798%
+(Better All-in) 79.899%
+(Re.s) 0.606061%
+(Better Mean Rank) 79.8335%
+(Ra.s) 0%
+
+*
+Ts Ah Bet to call 10 (from 0) at 35 pot, 
+CallStrength W(1m)=0.79596 L=0.19798 o.w_s=(0.79596,0.00606061)
+(MinRaise to $20) 	W(1x)=0.79596 L=0.19798 1o.w_s=(0.79596,0.00606061)
+ -  stat_high algb SLIDERX - 
+9 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 10
+Choice Fold 75
+f(10)=1.02413
+CALL 10
+FoldGain()M=0.993289 x 0(=0 folds)	vs play:1.01742
+ AgainstCall(10)=1.01742 from +$25.9545 @ 1
+AgainstRaise(10)=1 from $0 @ 0
+        Push(10)=1 from $0 @ 0
+ AgainstCall(20)=1.01107 from +$31.9343 @ 0.51653
+AgainstRaise(20)=0.999011 from -$3.04655 @ 0.48347
+        Push(20)=1 from $0 @ 0
+OppRAISEChanceM [*] 0 @ $20 ($0 now)	fold -- 0	W(1x)=0.79596 L=0.19798 1o.w_s=(0.79596,0.00606061)
+OppRAISEChanceM [*] 0 @ $30 ($0 now)	fold -- 0.20223	W(1x)=0.79596 L=0.19798 1o.w_s=(0.79596,0.00606061)
+OppRAISEChanceM [*] 0 @ $50 ($0 now)	fold -- 0.45183	W(5.66667x)=0 L=1 1o.w_s=(0,0)
+OppRAISEChanceM [*] 0 @ $90 ($0 now)	fold -- 0.619327	W(6.66667x)=0 L=1 1o.w_s=(0,0)
+OppRAISEChanceM [*] 0 @ $170 ($0 now)	fold -- 0.711005	W(8.33333x)=0 L=1 1o.w_s=(0,0)
+OppRAISEChanceM [*] 0 @ $330 ($0 now)	fold -- 0.775785	W(11x)=0 L=1 1o.w_s=(0,0)
+OppRAISEChanceM [*] 0 @ $650 ($0 now)	fold -- 0.812263	W(14.8333x)=0 L=1 1o.w_s=(0,0)
+OppRAISEChanceM [*] 0 @ $1290 ($0 now)	fold -- 0.841404	W(20.3333x)=0 L=1 1o.w_s=(0,0)
+OppRAISEChanceM [*] 0 @ $1490 ($0 now)	fold -- 0.827211	W(15.6667x)=0 L=1 1o.w_s=(0,0)
+
+(Fixed at $10)	W(1x)=0.79596 L=0.19798 1o.w_s=(0.79596,0.00606061)
+Guaranteed > $25 is in the pot for sure
+OppFoldChance% ...    0   d\0

--- a/holdem/unittests/playlogs.expected/13a.txt
+++ b/holdem/unittests/playlogs.expected/13a.txt
@@ -1,0 +1,50 @@
+
+==========#13==========
+Playing as ~
+*
+(M) 58.1347%
+(M.w) 56.9062%
+(M.s) 2.45692%
+(M.l) 40.6369%
+(Better All-in) 65.4286%
+(Re.s) 0.244898%
+(Better Mean Rank) 81.1837%
+(Ra.s) 0.571429%
+
+*
+Jc Qd Bet to call 55 (from 10) at 65 pot, 
+Community outcomes (stdev = 0.178195 pcts , avgdev = 0.158877 pcts ), kurtosis = -1.27061
+0.270373 pct: least helpful community
+0.349659 pct: 1305 / 19600 (6.65816%)
+0.431609 pct: 7212 / 19600 (36.7959%)
+0.528326 pct: 3295 / 19600 (16.8112%)
+0.581347 pct (mean): mean- 0.600459   mean+ 0.399541 (skew 0.459758 tail right) 
+0.618214 pct: 1386 / 19600 (7.07143%)
+0.771736 pct: 1769 / 19600 (9.02551%)
+0.818028 pct: 4043 / 19600 (20.6276%)
+0.940948 pct: 590 / 19600 (3.0102%)
+0.999955 pct: most helpful community
+CallStrength W(1m)=0.569062 L=0.406369 o.w_s=(0.569062,0.0245692)
+(MinRaise to $100) 	W(1x)=0.569062 L=0.406369 1o.w_s=(0.569062,0.0245692)
+ -  stat_low geom SLIDERX - 
+9 dealt, 8 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 55
+Choice Fold 55
+f(55)=1.00634
+CALL 55
+FoldGain()R=0.999148 x 0(=0 folds)	vs play:1.00549   ->assumes $10 forced
+ AgainstCall(55)=1.00549 from +$8.94816 @ 1
+AgainstRaise(55)=1 from $0 @ 0
+        Push(55)=1 from $0 @ 0
+ AgainstCall(100)=1.0044 from +$13.3464 @ 0.538229
+AgainstRaise(100)=0.971187 from -$100 @ 0.461771
+        Push(100)=1 from $0 @ 0
+OppRAISEChanceR [*] 0 @ $100 ($45 now)	fold -- 0	W(1x)=0.569062 L=0.406369 1o.w_s=(0.569062,0.0245692)
+OppRAISEChanceR [*] 0 @ $155 ($45 now)	fold -- 0.0537634	W(1x)=0.569062 L=0.406369 1o.w_s=(0.569062,0.0245692)
+OppRAISEChanceR [*] 0 @ $255 ($46.9084 now)	fold -- 0.155646	W(5.33333x)=0.356636 L=0.634716 1o.w_s=(0.356636,0.00864828)
+OppRAISEChanceR [*] 0 @ $455 ($60.5831 now)	fold -- 0.446018	W(6.83333x)=0.336669 L=0.653749 1o.w_s=(0.336669,0.00958146)
+OppRAISEChanceR [*] 0 @ $810 ($75.1599 now)	fold -- 0.552611	W(6.5x)=0.340739 L=0.649797 1o.w_s=(0.340739,0.00946363)
+
+(Fixed at $55)	W(1x)=0.569062 L=0.406369 1o.w_s=(0.569062,0.0245692)
+Guaranteed > $0 is in the pot for sure
+OppFoldChance% ...    0   d\0

--- a/holdem/unittests/playlogs.expected/14a.txt
+++ b/holdem/unittests/playlogs.expected/14a.txt
@@ -1,0 +1,102 @@
+
+==========#14==========
+Playing as ~
+*
+(M) 82.3957%
+(M.w) 82.1173%
+(M.s) 0.556689%
+(M.l) 17.326%
+(Better All-in) 99.4694%
+(Re.s) 0.0816327%
+(Better Mean Rank) 99.4694%
+(Ra.s) 0.0816327%
+
+*
+Ks Kd Bet to call 10 (from 5) at 15 pot, 
+Community outcomes (stdev = 0.0619739 pcts , avgdev = 0.0443313 pcts ), kurtosis = 1.05791
+0.586776 pct: least helpful community
+0.622478 pct: 90 / 19600 (0.459184%)
+0.683884 pct: 516 / 19600 (2.63265%)
+0.742801 pct: 2048 / 19600 (10.449%)
+0.795935 pct: 6332 / 19600 (32.3061%)
+0.823957 pct (mean): mean- 0.498469   mean+ 0.501531 (skew 0.26942 tail right) 
+0.842216 pct: 8336 / 19600 (42.5306%)
+0.918368 pct: 698 / 19600 (3.56122%)
+0.96063 pct: 1580 / 19600 (8.06122%)
+0.999966 pct: most helpful community
+CallStrength W(1m)=0.821173 L=0.17326 o.w_s=(0.821173,0.00556689)
+(MinRaise to $20) 	W(1x)=0.821173 L=0.17326 1o.w_s=(0.821173,0.00556689)
+ -  statrelation geom RAW - 
+9 dealt, 8 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 20
+Choice Fold 70
+f(10)=1.01947
+*MinRaise 20
+RAISETO 20
+
+FoldGain()R=0.998285 x 0(=0 folds)	vs play:1.01934   ->assumes $5 forced
+ AgainstCall(20)=1.00311 from +$12.8156 @ 0.19775
+AgainstRaise(20)=1.01122 from +$20.1185 @ 0.454801
+        Push(20)=1.00491 from +$11.4893 @ 0.347449
+ AgainstCall(10)=1.00431 from +$6.47914 @ 0.540405
+AgainstRaise(10)=1.01339 from +$23.7775 @ 0.459595
+        Push(10)=1 from $0 @ 0
+
+Why didn't I call?
+OppRAISEChanceR [*] 0.459595 @ $20 ($10 now)	fold -- 0.347449	W(1x)=0.821173 L=0.17326 1o.w_s=(0.821173,0.00556689)
+OppRAISEChanceR [*] 0.457198 @ $30 ($10 now)	fold -- 0.437916	W(5.66667x)=0.691699 L=0.29963 1o.w_s=(0.691699,0.00867115)
+OppRAISEChanceR [*] 0.447505 @ $50 ($0 now)	fold -- 0.549788	W(7x)=0.677045 L=0.313143 1o.w_s=(0.677045,0.00981248)
+OppRAISEChanceR [*] 0.432199 @ $90 ($12.9536 now)	fold -- 0.666304	W(9x)=0.666416 L=0.322149 1o.w_s=(0.666416,0.0114353)
+OppRAISEChanceR [*] 0.412185 @ $170 ($16.437 now)	fold -- 0.754933	W(12x)=0.651814 L=0.334279 1o.w_s=(0.651814,0.0139072)
+OppRAISEChanceR [*] 0.356537 @ $330 ($21.2636 now)	fold -- 0.815794	W(16.3333x)=0.632385 L=0.350212 1o.w_s=(0.632385,0.0174033)
+OppRAISEChanceR [F] 0.0460013 @ $650 ($25.3887 now)	fold -- 0.850929	W(22.6667x)=0.606878 L=0.371074 1o.w_s=(0.606878,0.0220478)
+OppRAISEChanceR [F] 0 @ $810 ($26.996 now)	fold -- 0.869069	W(25.1667x)=0.598322 L=0.377692 1o.w_s=(0.598322,0.0239863)
+
+(Fixed at $20)	W(1x)=0.821173 L=0.17326 1o.w_s=(0.821173,0.00556689)
+	--
+What am I expecting now, given my actual bet?
+OppRAISEChanceR [*] 0.454801 @ $30 ($10 now)
+OppRAISEChanceR [*] 0.446741 @ $50 ($10 now)
+OppRAISEChanceR [*] 0.426537 @ $90 ($12.3624 now)
+OppRAISEChanceR [*] 0.411423 @ $170 ($15.9653 now)
+OppRAISEChanceR [*] 0.355778 @ $330 ($20.9801 now)
+OppRAISEChanceR [F] 0.0705007 @ $650 ($25.2628 now)
+OppRAISEChanceR [F] 0 @ $810 ($26.8734 now)
+Guaranteed > $0 is in the pot for sure
+OppFoldChance% ...    0.347449   d\0.0140668
+if playstyle is Danger/Conservative, overall utility is 0.0210555
+
+*
+Ks Kd Bet to call 365 (from 20) at 385 pot, 
+Community outcomes (stdev = 0.0619739 pcts , avgdev = 0.0443313 pcts ), kurtosis = 1.05791
+0.586776 pct: least helpful community
+0.622478 pct: 90 / 19600 (0.459184%)
+0.683884 pct: 516 / 19600 (2.63265%)
+0.742801 pct: 2048 / 19600 (10.449%)
+0.795935 pct: 6332 / 19600 (32.3061%)
+0.823957 pct (mean): mean- 0.498469   mean+ 0.501531 (skew 0.26942 tail right) 
+0.842216 pct: 8336 / 19600 (42.5306%)
+0.918368 pct: 698 / 19600 (3.56122%)
+0.96063 pct: 1580 / 19600 (8.06122%)
+0.999966 pct: most helpful community
+CallStrength W(1m)=0.821173 L=0.17326 o.w_s=(0.821173,0.00556689)
+(MinRaise to $710) 	W(1x)=0.821173 L=0.17326 1o.w_s=(0.821173,0.00556689)
+ -  statrelation geom RAW - 
+9 dealt, 8 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 365
+Choice Fold 460
+f(365)=1.31048
+CALL 365
+FoldGain()R=0.981481 x 0(=0 folds)	vs play:1.29196   ->assumes $5 forced
+ AgainstCall(365)=1.29196 from +$236.488 @ 1
+AgainstRaise(365)=1 from $0 @ 0
+        Push(365)=1 from $0 @ 0
+ AgainstCall(710)=1 from $0 @ 0
+AgainstRaise(710)=0.123457 from -$710 @ 1
+        Push(710)=1 from $0 @ 0
+OppRAISEChanceR [*] 0 @ $710 ($345 now)	fold -- 0	W(1x)=0.821173 L=0.17326 1o.w_s=(0.821173,0.00556689)
+OppRAISEChanceR [F] 0 @ $810 ($345 now)	fold -- 0.0202541	W(1x)=0.821173 L=0.17326 1o.w_s=(0.821173,0.00556689)
+
+(Fixed at $365)	W(1x)=0.821173 L=0.17326 1o.w_s=(0.821173,0.00556689)
+Guaranteed > $0 is in the pot for sure
+OppFoldChance% ...    0   d\0

--- a/holdem/unittests/playlogs.expected/17.txt
+++ b/holdem/unittests/playlogs.expected/17.txt
@@ -1,0 +1,216 @@
+
+==========#17==========
+Playing as ~
+*
+(M) 60.984%
+(M.w) 59.3867%
+(M.s) 3.19457%
+(M.l) 37.4188%
+(Better All-in) 88.3673%
+(Re.s) 0.244898%
+(Better Mean Rank) 89.5918%
+(Ra.s) 0.244898%
+
+*
+7h Ah Bet to call 10 (from 0) at 25 pot, 
+Community outcomes (stdev = 0.146186 pcts , avgdev = 0.126373 pcts ), kurtosis = -0.67018
+0.34343 pct: least helpful community
+0.400516 pct: 645 / 19600 (3.29082%)
+0.48564 pct: 7824 / 19600 (39.9184%)
+0.568835 pct: 3192 / 19600 (16.2857%)
+0.60984 pct (mean): mean- 0.588827   mean+ 0.411173 (skew 0.674055 tail right) 
+0.680334 pct: 3569 / 19600 (18.2092%)
+0.762663 pct: 1254 / 19600 (6.39796%)
+0.843879 pct: 2463 / 19600 (12.5663%)
+0.943631 pct: 653 / 19600 (3.33163%)
+0.999966 pct: most helpful community
+CallStrength W(4r)=0.640764 L=0.352192 o.w_s=(0.894694,0.00244898)
+(MinRaise to $20) 	W(10.0135x)=0.298369 L=0.638504 4o.w_s=(0.643705,0.0316376)
+ -  stat_high algb SLIDERX - 
+9 dealt, 8 opp. (round), 4 opp. assumed str., 4 opp. still in
+Choice Optimal 10
+Choice Fold 15
+f(10)=1.04333
+CALL 10
+FoldGain()R=0.999076 x 0(=0 folds)	vs play:1.0424
+ AgainstCall(10)=1.00668 from +$12.8346 @ 0.781563
+AgainstRaise(10)=1.03573 from +$245.744 @ 0.218437
+        Push(10)=1 from $0 @ 0
+ AgainstCall(20)=0.999419 from -$2.03122 @ 0.429645
+AgainstRaise(20)=0.992408 from -$20 @ 0.570355
+        Push(20)=1 from $0 @ 0
+OppRAISEChanceR [*] 0.218437 @ $20 ($10 now)	fold -- 0	W(10.0135x)=0.298369 L=0.638504 4o.w_s=(0.643705,0.0316376)
+OppRAISEChanceR [*] 0.217566 @ $30 ($10 now)	fold -- 0.0205248	W(28.6987x)=0.2702 L=0.682846 4o.w_s=(0.641701,0.0262255)
+OppRAISEChanceR [*] 0.215827 @ $50 ($0 now)	fold -- 0.0615692	W(32.8853x)=0.263693 L=0.683109 4o.w_s=(0.639261,0.0300552)
+OppRAISEChanceR [*] 0.212364 @ $90 ($12.9536 now)	fold -- 0.237627	W(44.8494x)=0.257115 L=0.692756 4o.w_s=(0.638603,0.0290795)
+OppRAISEChanceR [*] 0.205486 @ $170 ($16.437 now)	fold -- 0.428447	W(56.7244x)=0.249078 L=0.699534 4o.w_s=(0.636752,0.0305695)
+OppRAISEChanceR [*] 0.191847 @ $330 ($21.2636 now)	fold -- 0.57367	W(75.3652x)=0.241705 L=0.713451 4o.w_s=(0.636632,0.0276718)
+OppRAISEChanceR [*] 0.161104 @ $650 ($25.3887 now)	fold -- 0.628125	W(100.437x)=0.232412 L=0.728359 4o.w_s=(0.63595,0.0252868)
+OppRAISEChanceR [*] 0.0947106 @ $1290 ($30.7344 now)	fold -- 0.721347	W(138.386x)=0.216672 L=0.747024 4o.w_s=(0.633233,0.0250044)
+OppRAISEChanceR [*] 0 @ $1502.5 ($31.9229 now)	fold -- 0.709794	W(105.77x)=0.230242 L=0.731078 4o.w_s=(0.635619,0.0251615)
+
+(Fixed at $10)	W(4x)=0.443759 L=0.502243 4o.w_s=(0.664814,0.0193619)
+Guaranteed > $0 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+3h 8c Kd community
+*
+(M) 50.842%
+(M.w) 49.3952%
+(M.s) 2.8936%
+(M.l) 47.7112%
+(Better All-in) 55.5042%
+(Re.s) 0.185014%
+(Better Mean Rank) 61.2245%
+(Ra.s) 0%
+
+*
+7h Ah Bet to call 0 (from 0) at 45 pot, 
+Community outcomes (stdev = 0.122116 pcts , avgdev = 0.0938032 pcts ), kurtosis = 1.87681
+0.40717 pct: least helpful community
+0.416571 pct: 24 / 47 (51.0638%)
+0.50842 pct (mean): mean- 0.510638   mean+ 0.489362 (skew 1.52556 tail right) 
+0.525613 pct: 7 / 47 (14.8936%)
+0.544499 pct: 8 / 47 (17.0213%)
+0.650011 pct: 4 / 47 (8.51064%)
+0.67881 pct: 1 / 47 (2.12766%)
+0.769514 pct: 0 / 47 (0%)
+0.861294 pct: 3 / 47 (6.38298%)
+0.868336 pct: most helpful community
+CallStrength W(3r)=0.229496 L=0.770504 o.w_s=(0.612245,0)
+(MinRaise to $10) 	W(7.5x)=0.111284 L=0.888337 3o.w_s=(0.543055,0.000614881)
+ -  stat_high algb SLIDERX - 
+9 dealt, 3 opp. (round), 3 opp. assumed str., 3 opp. still in
+Choice Optimal 0
+Choice Fold 15
+f(0)=1.01061
+CALL 0
+FoldGain()R=0.9933 x 0(=0 folds)	vs play:1.00391
+ AgainstCall(0)=1.00391 from +$10.3273 @ 0.564564
+AgainstRaise(0)=1 from $0 @ 0.435436
+        Push(0)=1 from $0 @ 0
+ AgainstCall(10)=0.99974 from -$1.20328 @ 0.322117
+AgainstRaise(10)=0.995458 from -$10 @ 0.677883
+        Push(10)=1 from $0 @ 0
+OppRAISEChanceR [*] 0.257096 @ $10 ($10 now)	fold -- 0	W(7.5x)=0.111284 L=0.888337 3o.w_s=(0.543055,0.000614881)
+OppRAISEChanceR [*] 0.256202 @ $20 ($10 now)	fold -- 0.012954	W(11.5x)=0.088502 L=0.910918 3o.w_s=(0.529223,0.00115411)
+OppRAISEChanceR [*] 0.25164 @ $40 ($11.4744 now)	fold -- 0.103218	W(20x)=0.047898 L=0.951093 3o.w_s=(0.493537,0.00344206)
+OppRAISEChanceR [F] 0.435436 @ $80 ($15.7323 now)	fold -- 0.238349	W(25.75x)=0.0442445 L=0.954456 3o.w_s=(0.488763,0.00473832)
+OppRAISEChanceR [F] 0.254748 @ $160 ($21.1531 now)	fold -- 0.367048	W(32x)=0.0415814 L=0.956804 3o.w_s=(0.484906,0.00619701)
+OppRAISEChanceR [F] 0.14129 @ $320 ($28.5992 now)	fold -- 0.436458	W(41.25x)=0.0391491 L=0.959647 3o.w_s=(0.482091,0.00489226)
+OppRAISEChanceR [F] 0.0582375 @ $640 ($36.4064 now)	fold -- 0.487974	W(55.75x)=0.0360663 L=0.962996 3o.w_s=(0.477964,0.0041068)
+OppRAISEChanceR [F] 0.0174075 @ $1280 ($46.9694 now)	fold -- 0.540276	W(76.25x)=0.0323403 L=0.966729 3o.w_s=(0.472065,0.00448555)
+OppRAISEChanceR [F] 0 @ $1492.5 ($50.1739 now)	fold -- 0.368791	W(58.75x)=0.0354523 L=0.96356 3o.w_s=(0.476956,0.00439076)
+
+(Fixed at $0)	W(3x)=0.142758 L=0.846096 3o.w_s=(0.55382,0.0140534)
+Guaranteed > $45 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+3h 8c Jh Kd community
+*
+(M) 54.3204%
+(M.w) 52.7361%
+(M.s) 3.16864%
+(M.l) 44.0953%
+(Better All-in) 46.087%
+(Re.s) 0%
+(Better Mean Rank) 59.7518%
+(Ra.s) 0%
+
+*
+7h Ah Bet to call 0 (from 0) at 45 pot, 
+Community outcomes (stdev = 0.257674 pcts , avgdev = 0.22167 pcts ), kurtosis = -0.849645
+0.315657 pct: least helpful community
+0.340476 pct: 21 / 46 (45.6522%)
+0.459091 pct: 10 / 46 (21.7391%)
+0.543204 pct (mean): mean- 0.673913   mean+ 0.326087 (skew 0.920966 tail right) 
+0.585859 pct: 3 / 46 (6.52174%)
+0.657828 pct: 0 / 46 (0%)
+0.755592 pct: 0 / 46 (0%)
+0.848485 pct: 3 / 46 (6.52174%)
+0.993715 pct: 9 / 46 (19.5652%)
+1 pct: most helpful community
+CallStrength W(3r)=0.21333 L=0.78667 o.w_s=(0.597518,0)
+(MinRaise to $10) 	W(7.5x)=0.20224 L=0.79776 3o.w_s=(0.586979,0)
+ -  stat_high algb SLIDERX - 
+9 dealt, 3 opp. (round), 3 opp. assumed str., 3 opp. still in
+Choice Optimal 0
+Choice Fold 20
+f(0)=1.01158
+CALL 0
+FoldGain()R=0.9933 x 0(=0 folds)	vs play:1.00488
+ AgainstCall(0)=1.00488 from +$9.59986 @ 0.757927
+AgainstRaise(0)=1 from $0 @ 0.242073
+        Push(0)=1 from $0 @ 0
+ AgainstCall(10)=1.00194 from +$6.16843 @ 0.470341
+AgainstRaise(10)=0.996451 from -$10 @ 0.529659
+        Push(10)=1 from $0 @ 0
+OppRAISEChanceR [*] 0.146415 @ $10 ($10 now)	fold -- 0	W(7.5x)=0.20224 L=0.79776 3o.w_s=(0.586979,0)
+OppRAISEChanceR [*] 0.145983 @ $20 ($0 now)	fold -- 0.0313433	W(11.5x)=0.183333 L=0.816667 3o.w_s=(0.568086,0)
+OppRAISEChanceR [*] 0.145123 @ $40 ($15.6155 now)	fold -- 0.0840301	W(20x)=0.172596 L=0.827404 3o.w_s=(0.556771,0)
+OppRAISEChanceR [F] 0.242073 @ $80 ($23.7176 now)	fold -- 0.211548	W(25.75x)=0.169944 L=0.830056 3o.w_s=(0.553905,0)
+OppRAISEChanceR [F] 0.141087 @ $160 ($35.306 now)	fold -- 0.318018	W(32x)=0.167062 L=0.832938 3o.w_s=(0.550756,0)
+OppRAISEChanceR [F] 0.0737651 @ $320 ($51.7964 now)	fold -- 0.372956	W(41.25x)=0.162796 L=0.837204 3o.w_s=(0.546028,0)
+OppRAISEChanceR [F] 0.0337058 @ $640 ($75.2992 now)	fold -- 0.463405	W(55.75x)=0.159091 L=0.840909 3o.w_s=(0.541853,0)
+OppRAISEChanceR [F] 0.00998458 @ $1280 ($109.464 now)	fold -- 0.519463	W(76.25x)=0.159091 L=0.840909 3o.w_s=(0.541853,0)
+OppRAISEChanceR [F] 0 @ $1492.5 ($119.066 now)	fold -- 0.521859	W(58.75x)=0.159091 L=0.840909 3o.w_s=(0.541853,0)
+
+(Fixed at $0)	W(3x)=0.239196 L=0.760804 3o.w_s=(0.620752,0)
+Guaranteed > $45 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+3h 4h 8c Jh Kd community
+*
+(M) 100%
+(M.w) 100%
+(M.s) 0%
+(M.l) 0%
+(Better All-in) 100%
+(Re.s) 0%
+(Better Mean Rank) 99.9537%
+(Ra.s) 0.0925069%
+
+*
+7h Ah Bet to call 0 (from 0) at 45 pot, 
+CallStrength W(3r)=0.997227 L=0 o.w_s=(0.999075,0.000925069)
+(MinRaise to $10) 	W(7.5x)=1 L=0 3o.w_s=(1,0)
+ -  stat_high algb SLIDERX - 
+9 dealt, 3 opp. (round), 3 opp. assumed str., 3 opp. still in
+Choice Optimal 21.582
+Choice Fold 1487.5
+f(0)=1.15546
+*MinRaise 10
+RAISETO 21.582
+
+FoldGain()R=0.9933 x 0(=0 folds)	vs play:1.34499
+ AgainstCall(21.582)=1.01928 from +$85.4488 @ 0.336768
+AgainstRaise(21.582)=1.31996 from +$997.731 @ 0.478619
+        Push(21.582)=1.00575 from +$46.4822 @ 0.184613
+ AgainstCall(0)=1.024 from +$44.9376 @ 0.797021
+AgainstRaise(0)=1.12476 from +$917.368 @ 0.202979
+        Push(0)=1 from $0 @ 0
+
+Why didn't I call?
+OppRAISEChanceR [*] 0.202979 @ $10 ($0 now)	fold -- 0.0159996	W(7.5x)=1 L=0 3o.w_s=(1,0)
+OppRAISEChanceR [*] 0.202547 @ $20 ($0 now)	fold -- 0.17462	W(11.5x)=1 L=0 3o.w_s=(1,0)
+OppRAISEChanceR [*] 0.196599 @ $40 ($0 now)	fold -- 0.329773	W(20x)=1 L=0 3o.w_s=(1,0)
+OppRAISEChanceR [*] 0.194887 @ $80 ($0 now)	fold -- 0.50802	W(25.75x)=1 L=0 3o.w_s=(1,0)
+OppRAISEChanceR [*] 0.186409 @ $160 ($0 now)	fold -- 0.662255	W(32x)=1 L=0 3o.w_s=(1,0)
+OppRAISEChanceR [*] 0.174634 @ $320 ($0 now)	fold -- 0.75918	W(41.25x)=1 L=0 3o.w_s=(1,0)
+OppRAISEChanceR [*] 0.151131 @ $640 ($0 now)	fold -- 0.823149	W(55.75x)=1 L=0 3o.w_s=(1,0)
+OppRAISEChanceR [*] 0.0869139 @ $1280 ($0 now)	fold -- 0.864641	W(76.25x)=1 L=0 3o.w_s=(1,0)
+OppRAISEChanceR [*] 0 @ $1492.5 ($0 now)	fold -- 0.846546	W(58.75x)=1 L=0 3o.w_s=(1,0)
+
+(Fixed at $21.582)	W(11.5x)=1 L=0 3o.w_s=(1,0)
+	--
+What am I expecting now, given my actual bet?
+OppRAISEChanceR [*] 0.478619 @ $43.1641 ($0 now)
+OppRAISEChanceR [*] 0.47506 @ $86.3281 ($0 now)
+OppRAISEChanceR [*] 0.457881 @ $172.656 ($0 now)
+OppRAISEChanceR [*] 0.433137 @ $345.312 ($0 now)
+OppRAISEChanceR [*] 0.370238 @ $690.625 ($0 now)
+OppRAISEChanceR [*] 0.196193 @ $1381.25 ($0 now)
+OppRAISEChanceR [*] 0 @ $1492.5 ($0 now)
+Guaranteed > $45 is in the pot for sure
+OppFoldChance% ...    0.184613   d\0.00585547
+if playstyle is Danger/Conservative, overall utility is 0.351685

--- a/holdem/unittests/playlogs.expected/18.txt
+++ b/holdem/unittests/playlogs.expected/18.txt
@@ -1,0 +1,216 @@
+
+==========#18==========
+Playing as ~
+*
+(M) 63.5633%
+(M.w) 62.5352%
+(M.s) 2.05617%
+(M.l) 35.4087%
+(Better All-in) 91.7143%
+(Re.s) 0.244898%
+(Better Mean Rank) 93.9184%
+(Ra.s) 0.571429%
+
+*
+Jd Ac Bet to call 10 (from 5) at 25 pot, 
+Community outcomes (stdev = 0.149149 pcts , avgdev = 0.131309 pcts ), kurtosis = -1.10414
+0.347162 pct: least helpful community
+0.419158 pct: 506 / 19600 (2.58163%)
+0.504877 pct: 6816 / 19600 (34.7755%)
+0.580865 pct: 5210 / 19600 (26.5816%)
+0.635633 pct (mean): mean- 0.647194   mean+ 0.352806 (skew 0.595307 tail right) 
+0.669955 pct: 930 / 19600 (4.7449%)
+0.781 pct: 1671 / 19600 (8.52551%)
+0.85014 pct: 3883 / 19600 (19.8112%)
+0.941024 pct: 584 / 19600 (2.97959%)
+0.999972 pct: most helpful community
+CallStrength W(2r)=0.838906 L=0.156601 o.w_s=(0.915918,0.00244898)
+(MinRaise to $20) 	W(2x)=0.57279 L=0.406879 2o.w_s=(0.612466,0.0107746)
+ -  statrelation geom RAW - 
+9 dealt, 8 opp. (round), 2 opp. assumed str., 2 opp. still in
+Choice Optimal 10
+Choice Fold 10
+f(10)=1.00201
+CALL 10
+FoldGain()R=0.999077 x 0(=0 folds)	vs play:1.00109   ->assumes $5 forced
+ AgainstCall(10)=1.00467 from +$15.2121 @ 0.463729
+AgainstRaise(10)=0.996431 from -$10 @ 0.536271
+        Push(10)=1 from $0 @ 0
+ AgainstCall(20)=1.00297 from +$10.1853 @ 0.440375
+AgainstRaise(20)=0.992541 from -$20 @ 0.559625
+        Push(20)=1 from $0 @ 0
+OppRAISEChanceR [*] 0.157358 @ $20 ($10 now)	fold -- 0	W(2x)=0.57279 L=0.406879 2o.w_s=(0.612466,0.0107746)
+OppRAISEChanceR [*] 0.156767 @ $30 ($10 now)	fold -- 0.0323786	W(8.3615x)=0.403005 L=0.526101 2o.w_s=(0.551871,0.0465756)
+OppRAISEChanceR [F] 0.536271 @ $50 ($0 now)	fold -- 0.100103	W(9.79594x)=0.370647 L=0.547038 2o.w_s=(0.53773,0.0567196)
+OppRAISEChanceR [F] 0.374431 @ $90 ($12.9536 now)	fold -- 0.376446	W(17.2803x)=0.322858 L=0.656181 2o.w_s=(0.528806,0.0168958)
+OppRAISEChanceR [F] 0.23023 @ $170 ($16.437 now)	fold -- 0.569397	W(22.4468x)=0.284611 L=0.68929 2o.w_s=(0.510779,0.0229061)
+OppRAISEChanceR [F] 0.124492 @ $330 ($21.2636 now)	fold -- 0.686158	W(29.5402x)=0.238662 L=0.728322 2o.w_s=(0.486164,0.032539)
+OppRAISEChanceR [F] 0.0580108 @ $650 ($25.3887 now)	fold -- 0.770066	W(40.5625x)=0.220616 L=0.736627 2o.w_s=(0.473767,0.0438784)
+OppRAISEChanceR [F] 0.0174173 @ $1290 ($30.7344 now)	fold -- 0.813959	W(55.7709x)=0.208419 L=0.746076 2o.w_s=(0.465837,0.048346)
+OppRAISEChanceR [F] 0 @ $1505 ($31.9375 now)	fold -- 0.802452	W(42.791x)=0.217402 L=0.737739 2o.w_s=(0.471388,0.0463541)
+
+(Fixed at $10)	W(2x)=0.57279 L=0.406879 2o.w_s=(0.612466,0.0107746)
+Guaranteed > $0 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+4h 7d Tc community
+*
+(M) 51.6625%
+(M.w) 51.0441%
+(M.s) 1.23679%
+(M.l) 47.7191%
+(Better All-in) 56.7993%
+(Re.s) 1.11008%
+(Better Mean Rank) 59.0136%
+(Ra.s) 0%
+
+*
+Jd Ac Bet to call 0 (from 0) at 30 pot, 
+Community outcomes (stdev = 0.136181 pcts , avgdev = 0.0962478 pcts ), kurtosis = 1.58373
+0.377481 pct: least helpful community
+0.415985 pct: 18 / 47 (38.2979%)
+0.48446 pct: 14 / 47 (29.7872%)
+0.516625 pct (mean): mean- 0.680851   mean+ 0.319149 (skew 1.61486 tail right) 
+0.549732 pct: 9 / 47 (19.1489%)
+0.626411 pct: 0 / 47 (0%)
+0.697534 pct: 0 / 47 (0%)
+0.768656 pct: 0 / 47 (0%)
+0.843936 pct: 6 / 47 (12.766%)
+0.87534 pct: most helpful community
+CallStrength W(2r)=0.316341 L=0.671048 o.w_s=(0.562442,0.0111008)
+(MinRaise to $10) 	W(2x)=0.258473 L=0.722716 2o.w_s=(0.499737,0.017866)
+ -  statrelation geom RAW - 
+9 dealt, 2 opp. (round), 2 opp. assumed str., 2 opp. still in
+Choice Optimal 0
+Choice Fold 15
+f(0)=1.00862
+CALL 0
+FoldGain()R=0.993311 x 0(=0 folds)	vs play:1.00193
+ AgainstCall(0)=1.00193 from +$9.67878 @ 0.298737
+AgainstRaise(0)=1 from $0 @ 0.701263
+        Push(0)=1 from $0 @ 0
+ AgainstCall(10)=1.001 from +$4.86329 @ 0.307372
+AgainstRaise(10)=0.995362 from -$10 @ 0.692628
+        Push(10)=1 from $0 @ 0
+OppRAISEChanceR [*] 0.576828 @ $10 ($10 now)	fold -- 0	W(2x)=0.258473 L=0.722716 2o.w_s=(0.499737,0.017866)
+OppRAISEChanceR [F] 0.701263 @ $20 ($10 now)	fold -- 0.0295487	W(8.88889x)=0.117803 L=0.873079 2o.w_s=(0.410382,0.0155863)
+OppRAISEChanceR [F] 0.596995 @ $40 ($11.4744 now)	fold -- 0.202787	W(14.2222x)=0.0957259 L=0.893536 2o.w_s=(0.388056,0.0211869)
+OppRAISEChanceR [F] 0.376477 @ $80 ($15.7323 now)	fold -- 0.311354	W(17.5556x)=0.085553 L=0.906794 2o.w_s=(0.378306,0.0165588)
+OppRAISEChanceR [F] 0.230208 @ $160 ($21.1531 now)	fold -- 0.442012	W(22.4444x)=0.0709225 L=0.925961 2o.w_s=(0.362939,0.00788919)
+OppRAISEChanceR [F] 0.111084 @ $320 ($28.5992 now)	fold -- 0.506261	W(29.7778x)=0.0546936 L=0.945306 2o.w_s=(0.341955,3.24669e-16)
+OppRAISEChanceR [F] 0.0508787 @ $640 ($36.4064 now)	fold -- 0.596695	W(40.4444x)=0.0507666 L=0.949233 2o.w_s=(0.335644,3.30774e-16)
+OppRAISEChanceR [F] 0.0152016 @ $1280 ($46.9694 now)	fold -- 0.626271	W(55.7778x)=0.0451215 L=0.954879 2o.w_s=(0.325897,8.51666e-17)
+OppRAISEChanceR [F] 0 @ $1495 ($50.2121 now)	fold -- 0.530457	W(43.1111x)=0.0497848 L=0.950215 2o.w_s=(0.33401,4.1549e-17)
+
+(Fixed at $0)	W(2x)=0.258473 L=0.722716 2o.w_s=(0.499737,0.017866)
+Guaranteed > $30 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+4h 7d Tc Ad community
+*
+(M) 86.7874%
+(M.w) 86.4976%
+(M.s) 0.57971%
+(M.l) 12.9227%
+(Better All-in) 92.8502%
+(Re.s) 0.57971%
+(Better Mean Rank) 96.4539%
+(Ra.s) 0%
+
+*
+Jd Ac Bet to call 0 (from 0) at 30 pot, 
+Community outcomes (stdev = 0.0392543 pcts , avgdev = 0.0290686 pcts ), kurtosis = 1.179
+0.808081 pct: least helpful community
+0.815354 pct: 5 / 46 (10.8696%)
+0.842857 pct: 14 / 46 (30.4348%)
+0.865197 pct: 11 / 46 (23.913%)
+0.867874 pct (mean): mean- 0.543478   mean+ 0.456522 (skew 1.17158 tail right) 
+0.883655 pct: 11 / 46 (23.913%)
+0.9136 pct: 0 / 46 (0%)
+0.937049 pct: 0 / 46 (0%)
+0.961616 pct: 5 / 46 (10.8696%)
+0.972222 pct: most helpful community
+CallStrength W(2r)=0.856743 L=0.132492 o.w_s=(0.925604,0.0057971)
+(MinRaise to $10) 	W(2x)=0.755248 L=0.233158 2o.w_s=(0.657929,0.00503087)
+ -  statrelation geom RAW - 
+9 dealt, 2 opp. (round), 2 opp. assumed str., 2 opp. still in
+Choice Optimal 0
+Choice Fold 30
+f(0)=1.0155
+CALL 0
+FoldGain()R=0.993311 x 0(=0 folds)	vs play:1.00881
+ AgainstCall(0)=1.00881 from +$25.8636 @ 0.511171
+AgainstRaise(0)=1 from $0 @ 0.488829
+        Push(0)=1 from $0 @ 0
+ AgainstCall(10)=1.00976 from +$31.9912 @ 0.458539
+AgainstRaise(10)=0.996373 from -$10 @ 0.541461
+        Push(10)=1 from $0 @ 0
+OppRAISEChanceR [*] 0.412039 @ $10 ($10 now)	fold -- -3.92733e-18	W(2x)=0.755248 L=0.233158 2o.w_s=(0.657929,0.00503087)
+OppRAISEChanceR [*] 0.41115 @ $20 ($0 now)	fold -- 0.218741	W(8.88889x)=0.325916 L=0.622554 2o.w_s=(0.524381,0.0399337)
+OppRAISEChanceR [F] 0.488829 @ $40 ($15.6155 now)	fold -- 0.361079	W(14.2222x)=0.116176 L=0.859454 2o.w_s=(0.402885,0.0402448)
+OppRAISEChanceR [F] 0.313692 @ $80 ($23.7176 now)	fold -- 0.555082	W(17.5556x)=0.103948 L=0.896052 2o.w_s=(0.322409,0)
+OppRAISEChanceR [F] 0.179133 @ $160 ($35.306 now)	fold -- 0.676123	W(22.4444x)=0.0822622 L=0.917738 2o.w_s=(0.286814,0)
+OppRAISEChanceR [F] 0.0854887 @ $320 ($51.7964 now)	fold -- 0.747881	W(29.7778x)=0.0539745 L=0.946025 2o.w_s=(0.340826,6.5149e-16)
+OppRAISEChanceR [F] 0.0342135 @ $640 ($75.2992 now)	fold -- 0.801899	W(40.4444x)=0.0415386 L=0.958461 2o.w_s=(0.20381,0)
+OppRAISEChanceR [F] 0.0101602 @ $1280 ($109.464 now)	fold -- 0.831644	W(55.7778x)=0.0314376 L=0.968562 2o.w_s=(0.297747,9.32187e-17)
+OppRAISEChanceR [F] 0 @ $1495 ($119.175 now)	fold -- 0.822522	W(43.1111x)=0.0397819 L=0.960218 2o.w_s=(0.315796,4.834e-16)
+
+(Fixed at $0)	W(2x)=0.755248 L=0.233158 2o.w_s=(0.657929,0.00503087)
+Guaranteed > $30 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+4h 7d Tc Ah Ad community
+*
+(M) 97.2222%
+(M.w) 97.0707%
+(M.s) 0.30303%
+(M.l) 2.62626%
+(Better All-in) 97.2222%
+(Re.s) 0.30303%
+(Better Mean Rank) 97.4098%
+(Ra.s) 0%
+
+*
+Jd Ac Bet to call 0 (from 0) at 30 pot, 
+CallStrength W(2r)=0.942272 L=0.0518355 o.w_s=(0.970707,0.0030303)
+(MinRaise to $10) 	W(2x)=0.941414 L=0.0525253 2o.w_s=(0.695956,0.00223661)
+ -  statrelation geom RAW - 
+9 dealt, 2 opp. (round), 2 opp. assumed str., 2 opp. still in
+Choice Optimal 10
+Choice Fold 185
+f(0)=1.02173
+*MinRaise 10
+RAISETO 10
+
+FoldGain()R=0.993311 x 0(=0 folds)	vs play:1.01847
+ AgainstCall(10)=1.01477 from +$42.6365 @ 0.521489
+AgainstRaise(10)=1.00364 from +$11.396 @ 0.478511
+        Push(10)=1 from $0 @ 0
+ AgainstCall(0)=1.00981 from +$28.3565 @ 0.519584
+AgainstRaise(0)=1.00518 from +$16.1702 @ 0.480416
+        Push(0)=1 from $0 @ 0
+
+Why didn't I call?
+OppRAISEChanceR [*] 0.480416 @ $10 ($0 now)	fold -- 0	W(2x)=0.941414 L=0.0525253 2o.w_s=(0.695956,0.00223661)
+OppRAISEChanceR [*] 0.47958 @ $20 ($0 now)	fold -- 0.1872	W(8.88889x)=0.739618 L=0.233446 2o.w_s=(0.652809,0.011781)
+OppRAISEChanceR [*] 0.477909 @ $40 ($0 now)	fold -- 0.477362	W(14.2222x)=0.583389 L=0.373513 2o.w_s=(0.61245,0.0222192)
+OppRAISEChanceR [*] 0.474573 @ $80 ($0 now)	fold -- 0.626094	W(17.5556x)=0.485746 L=0.461055 2o.w_s=(0.582602,0.0310744)
+OppRAISEChanceR [F] 0.101246 @ $160 ($0 now)	fold -- 0.723273	W(22.4444x)=0.342536 L=0.58945 2o.w_s=(0.528575,0.050102)
+OppRAISEChanceR [F] 0.0640703 @ $320 ($0 now)	fold -- 0.788795	W(29.7778x)=0.127722 L=0.782043 2o.w_s=(0.393645,0.120586)
+OppRAISEChanceR [F] 0.0346024 @ $640 ($0 now)	fold -- 0.841453	W(40.4444x)=0 L=1 2o.w_s=(0,0)
+OppRAISEChanceR [F] 0.0115416 @ $1280 ($0 now)	fold -- 0.871611	W(55.7778x)=0 L=1 2o.w_s=(0,0)
+OppRAISEChanceR [F] 0 @ $1495 ($0 now)	fold -- 0.859303	W(43.1111x)=0 L=1 2o.w_s=(0,0)
+
+(Fixed at $10)	W(2x)=0.941414 L=0.0525253 2o.w_s=(0.695956,0.00223661)
+	--
+What am I expecting now, given my actual bet?
+OppRAISEChanceR [*] 0.478511 @ $20 ($0 now)
+OppRAISEChanceR [*] 0.476844 @ $40 ($0 now)
+OppRAISEChanceR [*] 0.473515 @ $80 ($0 now)
+OppRAISEChanceR [F] 0.141737 @ $160 ($0 now)
+OppRAISEChanceR [F] 0.085956 @ $320 ($0 now)
+OppRAISEChanceR [F] 0.0518106 @ $640 ($0 now)
+OppRAISEChanceR [F] 0.0174614 @ $1280 ($0 now)
+OppRAISEChanceR [F] 0 @ $1495 ($0 now)
+Guaranteed > $30 is in the pot for sure
+OppFoldChance% ...    0   d\0

--- a/holdem/unittests/playlogs.expected/19.txt
+++ b/holdem/unittests/playlogs.expected/19.txt
@@ -1,0 +1,54 @@
+
+==========#19==========
+Playing as ~
+*
+(M) 56.0202%
+(M.w) 54.4316%
+(M.s) 3.17708%
+(M.l) 42.3913%
+(Better All-in) 74.7347%
+(Re.s) 0.244898%
+(Better Mean Rank) 73.9184%
+(Ra.s) 0.571429%
+
+*
+8s Kd Bet to call 10 (from 5) at 15 pot, 
+Community outcomes (stdev = 0.157237 pcts , avgdev = 0.136895 pcts ), kurtosis = -0.695193
+0.300854 pct: least helpful community
+0.375178 pct: 807 / 19600 (4.11735%)
+0.449406 pct: 10166 / 19600 (51.8673%)
+0.535433 pct: 2248 / 19600 (11.4694%)
+0.560202 pct (mean): mean- 0.650102   mean+ 0.349898 (skew 0.831037 tail right) 
+0.660018 pct: 1398 / 19600 (7.13265%)
+0.747083 pct: 2415 / 19600 (12.3214%)
+0.828482 pct: 2064 / 19600 (10.5306%)
+0.932226 pct: 502 / 19600 (2.56122%)
+0.999961 pct: most helpful community
+CallStrength W(1m)=0.544316 L=0.423913 o.w_s=(0.544316,0.0317708)
+(MinRaise to $20) 	W(1x)=0.544316 L=0.423913 1o.w_s=(0.544316,0.0317708)
+ -  stat_low geom SLIDERX - 
+9 dealt, 8 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 10
+Choice Fold 15
+f(10)=1.02475
+CALL 10
+FoldGain()R=0.999077 x 0(=0 folds)	vs play:1.02382   ->assumes $5 forced
+ AgainstCall(10)=1.00042 from +$1.20403 @ 0.531281
+AgainstRaise(10)=1.02339 from +$76.0939 @ 0.468719
+        Push(10)=1 from $0 @ 0
+ AgainstCall(20)=1.00038 from +$2.28126 @ 0.249265
+AgainstRaise(20)=0.990958 from -$20 @ 0.678975
+        Push(20)=1.00056 from +$11.8679 @ 0.0717593
+OppRAISEChanceR [*] 0.468719 @ $20 ($10 now)	fold -- 0.0717593	W(1x)=0.544316 L=0.423913 1o.w_s=(0.544316,0.0317708)
+OppRAISEChanceR [*] 0.466663 @ $30 ($10 now)	fold -- 0.145775	W(5.66667x)=0.294695 L=0.678838 1o.w_s=(0.294695,0.0264674)
+OppRAISEChanceR [*] 0.458471 @ $50 ($0 now)	fold -- 0.398119	W(7x)=0.273692 L=0.694668 1o.w_s=(0.273692,0.0316399)
+OppRAISEChanceR [*] 0.438002 @ $90 ($12.9536 now)	fold -- 0.565918	W(9x)=0.250999 L=0.709496 1o.w_s=(0.250999,0.0395046)
+OppRAISEChanceR [*] 0.421536 @ $170 ($16.437 now)	fold -- 0.665218	W(12x)=0.227665 L=0.72714 1o.w_s=(0.227665,0.0451946)
+OppRAISEChanceR [*] 0.353767 @ $330 ($21.2636 now)	fold -- 0.726338	W(16.3333x)=0.217968 L=0.742605 1o.w_s=(0.217968,0.0394277)
+OppRAISEChanceR [*] 0.270873 @ $650 ($25.3887 now)	fold -- 0.768967	W(22.6667x)=0.206164 L=0.758251 1o.w_s=(0.206164,0.0355852)
+OppRAISEChanceR [*] 0.127407 @ $1290 ($30.7344 now)	fold -- 0.810305	W(31.5x)=0.198258 L=0.779667 1o.w_s=(0.198258,0.0220749)
+OppRAISEChanceR [*] 0.00226244 @ $1500 ($31.9083 now)	fold -- 0.779127	W(24.1667x)=0.204801 L=0.762366 1o.w_s=(0.204801,0.0328328)
+
+(Fixed at $10)	W(1x)=0.544316 L=0.423913 1o.w_s=(0.544316,0.0317708)
+Guaranteed > $0 is in the pot for sure
+OppFoldChance% ...    0   d\0

--- a/holdem/unittests/playlogs.expected/2.txt
+++ b/holdem/unittests/playlogs.expected/2.txt
@@ -1,0 +1,55 @@
+
+==========#1==========
+Playing as ~
+*
+(M) 64.6024%
+(M.w) 63.4889%
+(M.s) 2.22694%
+(M.l) 34.2841%
+(Better All-in) 91.7959%
+(Re.s) 0.244898%
+(Better Mean Rank) 94.9796%
+(Ra.s) 0.244898%
+
+*
+Td Ad Bet to call 2.25 (from 0) at 3.375 pot, 
+Community outcomes (stdev = 0.14636 pcts , avgdev = 0.129032 pcts ), kurtosis = -1.02255
+0.340367 pct: least helpful community
+0.412595 pct: 546 / 19600 (2.78571%)
+0.498904 pct: 5052 / 19600 (25.7755%)
+0.571119 pct: 5187 / 19600 (26.4643%)
+0.646024 pct (mean): mean- 0.571071   mean+ 0.428929 (skew 0.445807 tail right) 
+0.681026 pct: 2345 / 19600 (11.9643%)
+0.764932 pct: 2631 / 19600 (13.4235%)
+0.851818 pct: 3027 / 19600 (15.4439%)
+0.943276 pct: 812 / 19600 (4.14286%)
+1 pct: most helpful community
+CallStrength W(4r)=0.706276 L=0.286146 o.w_s=(0.916735,0.00244898)
+(MinRaise to $4.5) 	W(26.0561x)=0.273817 L=0.680222 4o.w_s=(0.642549,0.0254156)
+ -  statrelation geom RAW - 
+8 dealt, 7 opp. (round), 4 opp. assumed str., 4 opp. still in
+Choice Optimal 2.25
+Choice Fold 2.25
+f(2.25)=0.998954
+CHECK/FOLD
+FoldGain()R=0.999522 x 0(=0 folds)	vs play:0.998476
+ AgainstCall(2.25)=1.00073 from +$1.83715 @ 0.283732
+AgainstRaise(2.25)=0.997751 from -$2.25 @ 0.716268
+        Push(2.25)=1 from $0 @ 0
+ AgainstCall(4.5)=0.999374 from -$1.47728 @ 0.303454
+AgainstRaise(4.5)=0.995837 from -$4.5 @ 0.662543
+        Push(4.5)=1.00018 from +$3.76267 @ 0.0340025
+OppRAISEChanceR [*] 0.284276 @ $4.5 ($2.25 now)	fold -- 0.0340025	W(26.0561x)=0.273817 L=0.680222 4o.w_s=(0.642549,0.0254156)
+OppRAISEChanceR [F] 0.716268 @ $6.75 ($2.25 now)	fold -- 0.0976762	W(31.9263x)=0.264397 L=0.681465 4o.w_s=(0.639211,0.0304725)
+OppRAISEChanceR [F] 0.566927 @ $11.25 ($0 now)	fold -- 0.311071	W(37.5686x)=0.261791 L=0.687703 4o.w_s=(0.63943,0.0288313)
+OppRAISEChanceR [F] 0.397726 @ $20.25 ($2.91456 now)	fold -- 0.453702	W(46.5763x)=0.256673 L=0.693559 4o.w_s=(0.638591,0.0289291)
+OppRAISEChanceR [F] 0.246042 @ $38.25 ($3.69833 now)	fold -- 0.563528	W(60.0779x)=0.248598 L=0.700944 4o.w_s=(0.636847,0.0301115)
+OppRAISEChanceR [F] 0.137313 @ $74.25 ($4.78431 now)	fold -- 0.656894	W(80.5371x)=0.242736 L=0.715215 4o.w_s=(0.637445,0.0259747)
+OppRAISEChanceR [F] 0.0704893 @ $146.25 ($5.71246 now)	fold -- 0.727415	W(110.189x)=0.232237 L=0.730297 4o.w_s=(0.636314,0.0242429)
+OppRAISEChanceR [F] 0.0324596 @ $290.25 ($6.91524 now)	fold -- 0.781574	W(152.278x)=0.216855 L=0.749468 4o.w_s=(0.633913,0.0232958)
+OppRAISEChanceR [F] 0.017782 @ $578.25 ($8.57921 now)	fold -- 0.825696	W(188.858x)=0.204536 L=0.766373 4o.w_s=(0.632293,0.0213744)
+OppRAISEChanceR [F] 0 @ $717 ($8.83531 now)	fold -- 0.834797	W(206.484x)=0.198562 L=0.774436 4o.w_s=(0.631456,0.0204525)
+
+(Fixed at $2.25)	W(4x)=0.516847 L=0.445933 4o.w_s=(0.674091,0.0118213)
+Guaranteed > $0 is in the pot for sure
+OppFoldChance% ...    0   d\0

--- a/holdem/unittests/playlogs.expected/21b.txt
+++ b/holdem/unittests/playlogs.expected/21b.txt
@@ -1,0 +1,218 @@
+
+==========#21==========
+Playing as ~
+*
+(M) 57.3789%
+(M.w) 55.5063%
+(M.s) 3.74527%
+(M.l) 40.7485%
+(Better All-in) 83.7143%
+(Re.s) 0.244898%
+(Better Mean Rank) 77.6327%
+(Ra.s) 0%
+
+9c Qh Kh community
+*
+(M) 64.5625%
+(M.w) 62.7032%
+(M.s) 3.71859%
+(M.l) 33.5782%
+(Better All-in) 57.8168%
+(Re.s) 0%
+(Better Mean Rank) 80.017%
+(Ra.s) 0%
+
+*
+2h Ah Bet to call 0 (from 0) at 14 pot, 
+Community outcomes (stdev = 0.188523 pcts , avgdev = 0.158717 pcts ), kurtosis = -0.664304
+0.494818 pct: least helpful community
+0.50744 pct: 24 / 47 (51.0638%)
+0.608041 pct: 11 / 47 (23.4043%)
+0.645625 pct (mean): mean- 0.744681   mean+ 0.255319 (skew 1.03497 tail right) 
+0.672581 pct: 0 / 47 (0%)
+0.743687 pct: 0 / 47 (0%)
+0.814792 pct: 0 / 47 (0%)
+0.868043 pct: 3 / 47 (6.38298%)
+0.985912 pct: 9 / 47 (19.1489%)
+0.992556 pct: most helpful community
+CallStrength W(6c)=0.215504 L=0.766558 o.w_s=(0.627032,0.0371859)
+(MinRaise to $2) 	W(11.1429x)=0.348109 L=0.646571 6o.w_s=(0.719648,0.00182164)
+ -  stat_low geom SLIDERX - 
+8 dealt, 6 opp. (round), 6 opp. assumed str., 6 opp. still in
+Choice Optimal 2
+Choice Fold 9
+f(0)=1.00138
+*MinRaise 2
+RAISETO 2
+
+FoldGain()R=0.99923 x 0(=0 folds)	vs play:1.00088
+ AgainstCall(2)=1.00129 from +$7.18577 @ 0.467369
+AgainstRaise(2)=0.99959 from -$2 @ 0.532631
+        Push(2)=1 from $0 @ 0
+ AgainstCall(0)=1.00061 from +$3.18432 @ 0.49984
+AgainstRaise(0)=1 from $0 @ 0.50016
+        Push(0)=1 from $0 @ 0
+
+Why didn't I call?
+OppRAISEChanceR [*] 0.123622 @ $2 ($2 now)	fold -- 0	W(11.1429x)=0.348109 L=0.646571 6o.w_s=(0.719648,0.00182164)
+OppRAISEChanceR [*] 0.123314 @ $4 ($2 now)	fold -- 0.00326665	W(16x)=0.332883 L=0.664365 6o.w_s=(0.719101,0.000987372)
+OppRAISEChanceR [*] 0.122699 @ $8 ($2.29487 now)	fold -- 0.0314747	W(17.1429x)=0.330498 L=0.666779 6o.w_s=(0.718959,0.000983942)
+OppRAISEChanceR [F] 0.50016 @ $16 ($3.14645 now)	fold -- 0.141336	W(47.7143x)=0.296137 L=0.703863 6o.w_s=(0.816423,0)
+OppRAISEChanceR [F] 0.326676 @ $32 ($4.23062 now)	fold -- 0.27373	W(57.7143x)=0.2894 L=0.7106 6o.w_s=(0.813298,0)
+OppRAISEChanceR [F] 0.186552 @ $64 ($5.71983 now)	fold -- 0.347646	W(74x)=0.278428 L=0.721572 6o.w_s=(0.808076,0)
+OppRAISEChanceR [F] 0.0908193 @ $128 ($7.28128 now)	fold -- 0.428258	W(93.7143x)=0.265146 L=0.734854 6o.w_s=(0.80152,0)
+OppRAISEChanceR [F] 0.0424342 @ $256 ($9.39388 now)	fold -- 0.507818	W(123.714x)=0.25544 L=0.74456 6o.w_s=(0.796553,0)
+OppRAISEChanceR [F] 0.0163298 @ $512 ($12.0496 now)	fold -- 0.542329	W(154.571x)=0.255411 L=0.744589 6o.w_s=(0.796538,0)
+OppRAISEChanceR [F] 0.0106234 @ $798 ($14.0969 now)	fold -- 0.537849	W(129.714x)=0.255434 L=0.744566 6o.w_s=(0.79655,0)
+
+(Fixed at $2)	W(11.1429x)=0.348109 L=0.646571 6o.w_s=(0.719648,0.00182164)
+	--
+What am I expecting now, given my actual bet?
+OppRAISEChanceR [*] 0.322321 @ $4 ($2 now)
+OppRAISEChanceR [*] 0.320058 @ $8 ($0 now)
+OppRAISEChanceR [*] 0.316157 @ $16 ($2.97255 now)
+OppRAISEChanceR [F] 0.532631 @ $32 ($4.11876 now)
+OppRAISEChanceR [F] 0.333128 @ $64 ($5.63528 now)
+OppRAISEChanceR [F] 0.172184 @ $128 ($7.23628 now)
+OppRAISEChanceR [F] 0.0855742 @ $256 ($9.36391 now)
+OppRAISEChanceR [F] 0.0297298 @ $512 ($12.0312 now)
+OppRAISEChanceR [F] 0.0224873 @ $798 ($14.0828 now)
+Guaranteed > $14 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+*
+2h Ah Bet to call 20 (from 2) at 56 pot, 
+Community outcomes (stdev = 0.188523 pcts , avgdev = 0.158717 pcts ), kurtosis = -0.664304
+0.494818 pct: least helpful community
+0.50744 pct: 24 / 47 (51.0638%)
+0.608041 pct: 11 / 47 (23.4043%)
+0.645625 pct (mean): mean- 0.744681   mean+ 0.255319 (skew 1.03497 tail right) 
+0.672581 pct: 0 / 47 (0%)
+0.743687 pct: 0 / 47 (0%)
+0.814792 pct: 0 / 47 (0%)
+0.868043 pct: 3 / 47 (6.38298%)
+0.985912 pct: 9 / 47 (19.1489%)
+0.992556 pct: most helpful community
+CallStrength W(6c)=0.215504 L=0.526433 o.w_s=(0.327185,0.0371859)
+(MinRaise to $38) 	W(6x)=0.385335 L=0.6118 2o.w_s=(0.556599,0.00206528)
+ -  stat_low geom SLIDERX - 
+8 dealt, 6 opp. (round), 6 opp. assumed str., 2 opp. still in
+Choice Optimal 20
+Choice Fold 21
+f(20)=1.00015
+CALL 20
+FoldGain()R=0.99846 x 0(=0 folds)	vs play:0.998607
+ AgainstCall(20)=1.00038 from +$1.28532 @ 0.770296
+AgainstRaise(20)=0.998226 from -$20 @ 0.229704
+        Push(20)=1 from $0 @ 0
+ AgainstCall(38)=1.00171 from +$8.67774 @ 0.512469
+AgainstRaise(38)=0.992842 from -$38 @ 0.487531
+        Push(38)=1 from $0 @ 0
+OppRAISEChanceR [*] 0 @ $38 ($18 now)	fold -- 0	W(6x)=0.385335 L=0.6118 2o.w_s=(0.556599,0.00206528)
+OppRAISEChanceR [*] 0 @ $58 ($18 now)	fold -- 0.0194523	W(6x)=0.385335 L=0.6118 2o.w_s=(0.556599,0.00206528)
+OppRAISEChanceR [*] 0 @ $96 ($21.256 now)	fold -- 0.115821	W(6x)=0.385335 L=0.6118 2o.w_s=(0.556599,0.00206528)
+OppRAISEChanceR [F] 0.229704 @ $172 ($29.0835 now)	fold -- 0.345715	W(11.9005x)=0.343481 L=0.650836 2o.w_s=(0.540217,0.00445016)
+OppRAISEChanceR [F] 0.0825274 @ $324 ($38.9408 now)	fold -- 0.521208	W(12.4802x)=0.340375 L=0.653666 2o.w_s=(0.538927,0.00469715)
+OppRAISEChanceR [F] 0.0273087 @ $628 ($51.1239 now)	fold -- 0.579842	W(14.5272x)=0.33564 L=0.660597 2o.w_s=(0.537462,0.00300411)
+OppRAISEChanceR [F] 0.00451977 @ $798 ($56.2461 now)	fold -- 0.663308	W(13.1057x)=0.338006 L=0.656293 2o.w_s=(0.53803,0.00451796)
+
+(Fixed at $20)	W(6x)=0.385335 L=0.6118 2o.w_s=(0.556599,0.00206528)
+Guaranteed > $14 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+9c Ts Qh Kh community
+*
+(M) 50.0318%
+(M.w) 47.1563%
+(M.s) 5.75099%
+(M.l) 47.0927%
+(Better All-in) 37.971%
+(Re.s) 0%
+(Better Mean Rank) 51.2411%
+(Ra.s) 0%
+
+*
+2h Ah Bet to call 0 (from 0) at 74 pot, 
+Community outcomes (stdev = 0.305257 pcts , avgdev = 0.276845 pcts ), kurtosis = -1.18731
+0.240909 pct: least helpful community
+0.24899 pct: 18 / 46 (39.1304%)
+0.358508 pct: 13 / 46 (28.2609%)
+0.500318 pct (mean): mean- 0.673913   mean+ 0.326087 (skew 0.787463 tail right) 
+0.512013 pct: 0 / 46 (0%)
+0.620455 pct: 0 / 46 (0%)
+0.709091 pct: 3 / 46 (6.52174%)
+0.837338 pct: 0 / 46 (0%)
+0.978746 pct: 12 / 46 (26.087%)
+1 pct: most helpful community
+CallStrength W(2c)=0.320009 L=0.631693 o.w_s=(0.471563,0.0575099)
+(MinRaise to $2) 	W(2x)=0.278371 L=0.715305 2o.w_s=(0.512174,0.0057852)
+ -  stat_low geom SLIDERX - 
+8 dealt, 2 opp. (round), 2 opp. assumed str., 2 opp. still in
+Choice Optimal 0
+Choice Fold 73
+f(0)=1.01328
+CALL 0
+FoldGain()R=0.991466 x 0(=0 folds)	vs play:1.00475
+ AgainstCall(0)=1.00539 from +$25.7691 @ 0.54071
+AgainstRaise(0)=0.999358 from -$3.60188 @ 0.45929
+        Push(0)=1 from $0 @ 0
+ AgainstCall(2)=1.00381 from +$20.2575 @ 0.48573
+AgainstRaise(2)=0.999601 from -$2 @ 0.51427
+        Push(2)=1 from $0 @ 0
+OppRAISEChanceR [*] 0.45929 @ $2 ($2 now)	fold -- 0	W(2x)=0.278371 L=0.715305 2o.w_s=(0.512174,0.0057852)
+OppRAISEChanceR [*] 0.458747 @ $4 ($0 now)	fold -- 0	W(2x)=0.278371 L=0.715305 2o.w_s=(0.512174,0.0057852)
+OppRAISEChanceR [*] 0.425328 @ $8 ($3.1231 now)	fold -- 0	W(2x)=0.278371 L=0.715305 2o.w_s=(0.512174,0.0057852)
+OppRAISEChanceR [*] 0.42312 @ $16 ($4.74352 now)	fold -- 0	W(2x)=0.278371 L=0.715305 2o.w_s=(0.512174,0.0057852)
+OppRAISEChanceR [*] 0.415244 @ $32 ($7.0612 now)	fold -- 0.0118633	W(2x)=0.278371 L=0.715305 2o.w_s=(0.512174,0.0057852)
+OppRAISEChanceR [*] 0.406352 @ $64 ($10.3593 now)	fold -- 0.0747754	W(2x)=0.278371 L=0.715305 2o.w_s=(0.512174,0.0057852)
+OppRAISEChanceR [*] 0.384166 @ $128 ($15.0598 now)	fold -- 0.313558	W(12.2222x)=0.21716 L=0.764578 2o.w_s=(0.477806,0.0196854)
+OppRAISEChanceR [F] 0.134047 @ $256 ($21.8928 now)	fold -- 0.427506	W(13.5556x)=0.21837 L=0.768289 2o.w_s=(0.479777,0.0144389)
+OppRAISEChanceR [F] 0.0480959 @ $512 ($31.0154 now)	fold -- 0.550959	W(15.7778x)=0.217426 L=0.768077 2o.w_s=(0.478939,0.0157089)
+OppRAISEChanceR [F] 0.00451977 @ $778 ($38.4961 now)	fold -- 0.581206	W(14.4444x)=0.217992 L=0.768204 2o.w_s=(0.479442,0.0149465)
+
+(Fixed at $0)	W(2x)=0.278371 L=0.715305 2o.w_s=(0.512174,0.0057852)
+Guaranteed > $74 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+4c 9c Ts Qh Kh community
+*
+(M) 25.7071%
+(M.w) 22.2222%
+(M.s) 6.9697%
+(M.l) 70.8081%
+(Better All-in) 25.7071%
+(Re.s) 6.9697%
+(Better Mean Rank) 22.2017%
+(Ra.s) 0%
+
+*
+2h Ah Bet to call 0 (from 0) at 74 pot, 
+CallStrength W(2r)=0.0493827 L=0.914783 o.w_s=(0.222222,0.069697)
+(MinRaise to $2) 	W(2x)=0 L=1 2o.w_s=(0,0)
+ -  stat_low geom SLIDERX - 
+8 dealt, 2 opp. (round), 2 opp. assumed str., 2 opp. still in
+Choice Optimal 0
+Choice Fold 17
+f(0)=1.00659
+CALL 0
+FoldGain()R=0.991466 x 0(=0 folds)	vs play:0.998058
+ AgainstCall(0)=1.0005 from +$4.92027 @ 0.264101
+AgainstRaise(0)=0.997555 from -$8.56134 @ 0.735899
+        Push(0)=1 from $0 @ 0
+ AgainstCall(2)=0.999794 from -$2 @ 0.264965
+AgainstRaise(2)=0.9979 from -$7.36281 @ 0.735035
+        Push(2)=1 from $0 @ 0
+OppRAISEChanceR [*] 0.735899 @ $2 ($0 now)	fold -- 0	W(2x)=0 L=1 2o.w_s=(0,0)
+OppRAISEChanceR [*] 0.735519 @ $4 ($0 now)	fold -- 0	W(2x)=0 L=1 2o.w_s=(0,0)
+OppRAISEChanceR [*] 0.73476 @ $8 ($0 now)	fold -- 0	W(2x)=0 L=1 2o.w_s=(0,0)
+OppRAISEChanceR [*] 0.733242 @ $16 ($0 now)	fold -- 0	W(2x)=0 L=1 2o.w_s=(0,0)
+OppRAISEChanceR [*] 0.730205 @ $32 ($0 now)	fold -- 0.0310765	W(2x)=0 L=1 2o.w_s=(0,0)
+OppRAISEChanceR [F] 0.441524 @ $64 ($0 now)	fold -- 0.0801899	W(2x)=0 L=1 2o.w_s=(0,0)
+OppRAISEChanceR [F] 0.31381 @ $128 ($0 now)	fold -- 0.281026	W(12.2222x)=0 L=1 2o.w_s=(0,0)
+OppRAISEChanceR [F] 0.156405 @ $256 ($0 now)	fold -- 0.433401	W(13.5556x)=0 L=1 2o.w_s=(0,0)
+OppRAISEChanceR [F] 0.0317113 @ $512 ($0 now)	fold -- 0.43023	W(15.7778x)=0 L=1 2o.w_s=(0,0)
+OppRAISEChanceR [F] 0.00226244 @ $778 ($0 now)	fold -- 0.380319	W(14.4444x)=0 L=1 2o.w_s=(0,0)
+
+(Fixed at $0)	W(2x)=0 L=1 2o.w_s=(0,0)
+Guaranteed > $74 is in the pot for sure
+OppFoldChance% ...    0   d\0

--- a/holdem/unittests/playlogs.expected/25.txt
+++ b/holdem/unittests/playlogs.expected/25.txt
@@ -1,0 +1,43 @@
+
+==========#25==========
+Playing as ~
+*
+(M) 45.0508%
+(M.w) 42.6933%
+(M.s) 4.71504%
+(M.l) 52.5917%
+(Better All-in) 24.1224%
+(Re.s) 0.244898%
+(Better Mean Rank) 33.7551%
+(Ra.s) 0.571429%
+
+*
+7s 8c Bet to call 74.2857 (from 0) at 171.429 pot, 
+Community outcomes (stdev = 0.197598 pcts , avgdev = 0.175887 pcts ), kurtosis = -0.92698
+0.177525 pct: least helpful community
+0.264054 pct: 6703 / 19600 (34.199%)
+0.34435 pct: 4428 / 19600 (22.5918%)
+0.450508 pct (mean): mean- 0.581224   mean+ 0.418776 (skew 0.642162 tail right) 
+0.470364 pct: 1855 / 19600 (9.46429%)
+0.618285 pct: 1436 / 19600 (7.32653%)
+0.69765 pct: 4319 / 19600 (22.0357%)
+0.831121 pct: 393 / 19600 (2.0051%)
+0.933594 pct: 466 / 19600 (2.37755%)
+0.999905 pct: most helpful community
+CallStrength W(5c)=0.0636722 L=0.88884 o.w_s=(0.356595,0.0471504)
+(MinRaise to $225.714) 	W(28.6938x)=0.170605 L=0.817847 4o.w_s=(0.629216,0.010388)
+ -  stat_high algb SLIDERX - 
+7 dealt, 6 opp. (round), 5 opp. assumed str., 4 opp. still in
+Choice Optimal 74.2857
+Choice Fold 74.2857
+f(74.2857)=-1.14259
+CHECK/FOLD
+FoldGain()R=2.3311 by waiting 31.3333hands(=20.8463 folds)	vs play:0.188516
+ AgainstCall(74.2857)=0.188516 from -$60.2817 @ 1
+AgainstRaise(74.2857)=1 from $0 @ 0
+        Push(74.2857)=1 from $0 @ 0
+OppRAISEChanceR [*] 0 @ $74.2857 ($0 now)	fold -- 0	W(27.3118x)=0.174392 L=0.811652 4o.w_s=(0.629392,0.0122303)
+
+(Fixed at $74.2857)	W(27.3118x)=0.174392 L=0.811652 4o.w_s=(0.629392,0.0122303)
+Guaranteed > $0 is in the pot for sure
+OppFoldChance% ...    0   ∇=0

--- a/holdem/unittests/playlogs.expected/26.txt
+++ b/holdem/unittests/playlogs.expected/26.txt
@@ -1,0 +1,218 @@
+
+==========#26==========
+Playing as ~
+*
+(M) 57.6965%
+(M.w) 55.7423%
+(M.s) 3.90848%
+(M.l) 40.3492%
+(Better All-in) 85.8367%
+(Re.s) 0.244898%
+(Better Mean Rank) 80.3673%
+(Ra.s) 0.571429%
+
+*
+5d As Bet to call 20 (from 2.85714) at 28.5714 pot, 
+Community outcomes (stdev = 0.144925 pcts , avgdev = 0.117082 pcts ), kurtosis = -0.258055
+0.306605 pct: least helpful community
+0.382359 pct: 624 / 19600 (3.18367%)
+0.460732 pct: 7749 / 19600 (39.5357%)
+0.553788 pct: 5084 / 19600 (25.9388%)
+0.576965 pct (mean): mean- 0.659133   mean+ 0.340867 (skew 0.936318 tail right) 
+0.650071 pct: 2508 / 19600 (12.7959%)
+0.769138 pct: 498 / 19600 (2.54082%)
+0.838613 pct: 2706 / 19600 (13.8061%)
+0.931698 pct: 431 / 19600 (2.19898%)
+0.999972 pct: most helpful community
+CallStrength W(5r)=0.329355 L=0.349508 o.w_s=(0.573895,0.00571429)
+(MinRaise to $34.2857) 	W(13.7433x)=0.262409 L=0.6964 2o.w_s=(0.496787,0.0375698)
+ -  stat_high algb SLIDERX - 
+9 dealt, 8 opp. (round), 5 opp. assumed str., 2 opp. still in
+Choice Optimal 20
+Choice Fold 20
+f(20)=1.02843
+CALL 20
+FoldGain()R=0.991582 x 0(=0 folds)	vs play:1.02001   ->assumes $2.85714 forced
+ AgainstCall(20)=1.02038 from +$2.11655 @ 0.907957
+AgainstRaise(20)=0.999628 from -$0.381132 @ 0.0920429
+        Push(20)=1 from $0 @ 0
+ AgainstCall(34.2857)=0.895716 from -$13.1415 @ 0.748198
+AgainstRaise(34.2857)=0.908435 from -$34.2857 @ 0.251802
+        Push(34.2857)=1 from $0 @ 0
+OppRAISEChanceR [*] 0.0920429 @ $34.2857 ($14.2857 now)	fold -- 0	W(13.7433x)=0.262409 L=0.6964 2o.w_s=(0.496787,0.0375698)
+OppRAISEChanceR [*] 0.0752251 @ $54.2857 ($14.2857 now)	fold -- 0.0316773	W(12.5556x)=0.264851 L=0.694228 2o.w_s=(0.498076,0.0370961)
+OppRAISEChanceR [*] 0.0440365 @ $88.5714 ($15.2625 now)	fold -- 0.035311	W(13.9444x)=0.261772 L=0.696486 2o.w_s=(0.496347,0.0381109)
+OppRAISEChanceR [*] 0 @ $94.2857 ($15.8249 now)	fold -- 0.0356356	W(12.2778x)=0.265843 L=0.694047 2o.w_s=(0.498745,0.0363037)
+
+(Fixed at $20)	W(12.4543x)=0.265209 L=0.694167 2o.w_s=(0.498319,0.0368065)
+Guaranteed > $0 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+6h 9s Tc community
+*
+(M) 40.9232%
+(M.w) 38.3367%
+(M.s) 5.17282%
+(M.l) 56.4904%
+(Better All-in) 47.5023%
+(Re.s) 0.647549%
+(Better Mean Rank) 31.0374%
+(Ra.s) 0%
+
+*
+5d As Bet to call 0 (from 0) at 60 pot, 
+Community outcomes (stdev = 0.127692 pcts , avgdev = 0.0950765 pcts ), kurtosis = 3.64989
+0.291184 pct: least helpful community
+0.335161 pct: 28 / 47 (59.5745%)
+0.369153 pct: 4 / 47 (8.51064%)
+0.409232 pct (mean): mean- 0.680851   mean+ 0.319149 (skew 1.97535 tail right) 
+0.477151 pct: 9 / 47 (19.1489%)
+0.545784 pct: 3 / 47 (6.38298%)
+0.631352 pct: 0 / 47 (0%)
+0.706944 pct: 0 / 47 (0%)
+0.813688 pct: 3 / 47 (6.38298%)
+0.820334 pct: most helpful community
+CallStrength W(2c)=0.163993 L=0.795754 o.w_s=(0.383367,0.0517282)
+(MinRaise to $5.71428) 	W(2x)=0.122803 L=0.837891 2o.w_s=(0.403822,0.0601458)
+ -  stat_high algb SLIDERX - 
+9 dealt, 2 opp. (round), 2 opp. assumed str., 2 opp. still in
+Choice Optimal 0
+Choice Fold 37.1428
+f(0)=1.30426
+CALL 0
+FoldGain()R=0.730769 x 0(=0 folds)	vs play:1.03503
+ AgainstCall(0)=1.08138 from +$11.0829 @ 0.545447
+AgainstRaise(0)=0.953651 from -$7.57466 @ 0.454553
+        Push(0)=1 from $0 @ 0
+ AgainstCall(5.71428)=1.04716 from +$5.51337 @ 0.635404
+AgainstRaise(5.71428)=0.922406 from -$15.8097 @ 0.364596
+        Push(5.71428)=1 from $0 @ 0
+OppRAISEChanceR [*] 0.454553 @ $5.71428 ($5.71428 now)	fold -- 0	W(2x)=0.122803 L=0.837891 2o.w_s=(0.403822,0.0601458)
+OppRAISEChanceR [*] 0.39083 @ $11.4286 ($5.71428 now)	fold -- 0	W(2x)=0.122803 L=0.837891 2o.w_s=(0.403822,0.0601458)
+OppRAISEChanceR [*] 0.354999 @ $22.8571 ($6.55677 now)	fold -- 0.000607475	W(2x)=0.122803 L=0.837891 2o.w_s=(0.403822,0.0601458)
+OppRAISEChanceR [*] 0.236073 @ $45.7142 ($8.98986 now)	fold -- 0.0117857	W(2x)=0.122803 L=0.837891 2o.w_s=(0.403822,0.0601458)
+OppRAISEChanceR [F] 0 @ $74.2857 ($11.0476 now)	fold -- 0.0154195	W(2x)=0.122803 L=0.837891 2o.w_s=(0.403822,0.0601458)
+
+(Fixed at $0)	W(2x)=0.122803 L=0.837891 2o.w_s=(0.403822,0.0601458)
+Guaranteed > $60 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+*
+5d As Bet to call 32.8571 (from 0) at 125.714 pot, 
+Community outcomes (stdev = 0.127692 pcts , avgdev = 0.0950765 pcts ), kurtosis = 3.64989
+0.291184 pct: least helpful community
+0.335161 pct: 28 / 47 (59.5745%)
+0.369153 pct: 4 / 47 (8.51064%)
+0.409232 pct (mean): mean- 0.680851   mean+ 0.319149 (skew 1.97535 tail right) 
+0.477151 pct: 9 / 47 (19.1489%)
+0.545784 pct: 3 / 47 (6.38298%)
+0.631352 pct: 0 / 47 (0%)
+0.706944 pct: 0 / 47 (0%)
+0.813688 pct: 3 / 47 (6.38298%)
+0.820334 pct: most helpful community
+CallStrength W(2c)=0.163993 L=0.795754 o.w_s=(0.383367,0.0517282)
+(MinRaise to $65.7142) 	W(2x)=0.122803 L=0.837891 2o.w_s=(0.403822,0.0601458)
+ -  stat_high algb SLIDERX - 
+9 dealt, 2 opp. (round), 2 opp. assumed str., 2 opp. still in
+Choice Optimal 32.8571
+Choice Fold 40
+f(32.8571)=1.21153
+CALL 32.8571
+FoldGain()R=0.730769 x 0(=0 folds)	vs play:0.942296
+ AgainstCall(32.8571)=0.942296 from -$4.28656 @ 1
+AgainstRaise(32.8571)=1 from $0 @ 0
+        Push(32.8571)=1 from $0 @ 0
+ AgainstCall(65.7142)=1 from -$34.0586 @ 0
+AgainstRaise(65.7142)=0.459008 from -$40.188 @ 1
+        Push(65.7142)=1 from $0 @ 0
+OppRAISEChanceR [*] 0 @ $65.7142 ($32.8571 now)	fold -- 0	W(2x)=0.122803 L=0.837891 2o.w_s=(0.403822,0.0601458)
+OppRAISEChanceR [*] 0 @ $74.2857 ($32.8571 now)	fold -- 0	W(2x)=0.122803 L=0.837891 2o.w_s=(0.403822,0.0601458)
+
+(Fixed at $32.8571)	W(2x)=0.122803 L=0.837891 2o.w_s=(0.403822,0.0601458)
+Guaranteed > $60 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+6h 9s Ts Tc community
+*
+(M) 47.7789%
+(M.w) 44.9561%
+(M.s) 5.64559%
+(M.l) 49.3983%
+(Better All-in) 53.1884%
+(Re.s) 4.34783%
+(Better Mean Rank) 54.344%
+(Ra.s) 0%
+
+*
+5d As Bet to call 0 (from 0) at 158.571 pot, 
+Community outcomes (stdev = 0.145831 pcts , avgdev = 0.120086 pcts ), kurtosis = 0.272136
+0.301515 pct: least helpful community
+0.324621 pct: 8 / 46 (17.3913%)
+0.413763 pct: 24 / 46 (52.1739%)
+0.477789 pct (mean): mean- 0.695652   mean+ 0.304348 (skew 1.14148 tail right) 
+0.492172 pct: 0 / 46 (0%)
+0.575126 pct: 4 / 46 (8.69565%)
+0.613384 pct: 4 / 46 (8.69565%)
+0.730303 pct: 3 / 46 (6.52174%)
+0.835354 pct: 3 / 46 (6.52174%)
+0.835354 pct: most helpful community
+CallStrength W(2r)=0.295327 L=0.704673 o.w_s=(0.54344,0)
+(MinRaise to $5.71428) 	W(2x)=0.0835968 L=0.803491 2o.w_s=(0.337842,0.180134)
+ -  stat_high algb SLIDERX - 
+9 dealt, 2 opp. (round), 2 opp. assumed str., 2 opp. still in
+Choice Optimal 0
+Choice Fold 41.4286
+f(0)=3.09258
+CALL 0
+FoldGain()R=0 x 0(=0 folds)	vs play:2.09258
+ AgainstCall(0)=1.93441 from +$46.8303 @ 0.826625
+AgainstRaise(0)=1.15817 from +$37.7962 @ 0.173375
+        Push(0)=1 from $0 @ 0
+ AgainstCall(5.71428)=1.41225 from +$20.5076 @ 0.832813
+AgainstRaise(5.71428)=1.04696 from +$11.6354 @ 0.167187
+        Push(5.71428)=1 from $0 @ 0
+OppRAISEChanceR [*] 0.173375 @ $5.71428 ($5.71428 now)	fold -- 0	W(2x)=0.0835968 L=0.803491 2o.w_s=(0.337842,0.180134)
+OppRAISEChanceR [*] 0.170098 @ $11.4286 ($0 now)	fold -- 0	W(2x)=0.0835968 L=0.803491 2o.w_s=(0.337842,0.180134)
+OppRAISEChanceR [*] 0.163067 @ $22.8571 ($8.92313 now)	fold -- 0	W(2x)=0.0835968 L=0.803491 2o.w_s=(0.337842,0.180134)
+OppRAISEChanceR [*] 0 @ $41.4286 ($12.7904 now)	fold -- 0	W(2x)=0.0835968 L=0.803491 2o.w_s=(0.337842,0.180134)
+
+(Fixed at $0)	W(2x)=0.0835968 L=0.803491 2o.w_s=(0.337842,0.180134)
+Guaranteed > $158.571 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+6h 8d 9s Ts Tc community
+*
+(M) 32.1717%
+(M.w) 29.899%
+(M.s) 4.54545%
+(M.l) 65.5556%
+(Better All-in) 32.1717%
+(Re.s) 4.54545%
+(Better Mean Rank) 29.6022%
+(Ra.s) 0%
+
+*
+5d As Bet to call 0 (from 0) at 158.571 pot, 
+CallStrength W(2r)=0.0876291 L=0.912371 o.w_s=(0.296022,0)
+(MinRaise to $5.71428) 	W(2x)=0 L=1 2o.w_s=(0,0)
+ -  stat_high algb SLIDERX - 
+9 dealt, 2 opp. (round), 2 opp. assumed str., 2 opp. still in
+Choice Optimal 0
+Choice Fold 2.85714
+f(0)=2.16812
+CALL 0
+FoldGain()R=0 x 0(=0 folds)	vs play:1.16812
+ AgainstCall(0)=1.21009 from +$13.8955 @ 0.626384
+AgainstRaise(0)=0.958025 from -$4.65436 @ 0.373616
+        Push(0)=1 from $0 @ 0
+ AgainstCall(5.71428)=0.912749 from -$5.71428 @ 0.632572
+AgainstRaise(5.71428)=0.799135 from -$22.6481 @ 0.367428
+        Push(5.71428)=1 from $0 @ 0
+OppRAISEChanceR [*] 0.373616 @ $5.71428 ($0 now)	fold -- 0	W(2x)=0 L=1 2o.w_s=(0,0)
+OppRAISEChanceR [*] 0.37034 @ $11.4286 ($0 now)	fold -- 0	W(2x)=0 L=1 2o.w_s=(0,0)
+OppRAISEChanceR [*] 0.363308 @ $22.8571 ($0 now)	fold -- 0	W(2x)=0 L=1 2o.w_s=(0,0)
+OppRAISEChanceR [*] 0 @ $41.4286 ($0 now)	fold -- 0	W(2x)=0 L=1 2o.w_s=(0,0)
+
+(Fixed at $0)	W(2x)=0 L=1 2o.w_s=(0,0)
+Guaranteed > $158.571 is in the pot for sure
+OppFoldChance% ...    0   d\0

--- a/holdem/unittests/playlogs.expected/27.txt
+++ b/holdem/unittests/playlogs.expected/27.txt
@@ -1,0 +1,47 @@
+
+==========#27==========
+Playing as ~
+*
+(M) 47.9081%
+(M.w) 45.8298%
+(M.s) 4.15674%
+(M.l) 50.0135%
+(Better All-in) 39.551%
+(Re.s) 0.244898%
+(Better Mean Rank) 43.6327%
+(Ra.s) 0.571429%
+
+*
+7c Td Bet to call 108 (from 0) at 114 pot, 
+Community outcomes (stdev = 0.181089 pcts , avgdev = 0.160279 pcts ), kurtosis = -0.817495
+0.213912 pct: least helpful community
+0.303204 pct: 4337 / 19600 (22.1276%)
+0.369411 pct: 7216 / 19600 (36.8163%)
+0.479081 pct (mean): mean- 0.623316   mean+ 0.376684 (skew 0.733022 tail right) 
+0.483678 pct: 1574 / 19600 (8.03061%)
+0.632759 pct: 1499 / 19600 (7.64796%)
+0.715898 pct: 4161 / 19600 (21.2296%)
+0.841404 pct: 388 / 19600 (1.97959%)
+0.927531 pct: 425 / 19600 (2.16837%)
+0.999905 pct: most helpful community
+CallStrength W(5c)=0.0684157 L=0.82511 o.w_s=(0.29575,0.0415674)
+(MinRaise to $212) 	W(35.7103x)=0.160343 L=0.824556 3o.w_s=(0.560073,0.0170585)
+ -  statranking algb RAW - 
+7 dealt, 6 opp. (round), 5 opp. assumed str., 3 opp. still in
+Choice Optimal 128
+Choice Fold 128
+f(108)=-2.0319
+raiseGain: f(128)=-2.0319
+CHECK/FOLD
+FoldGain()R=3.45147 x 55(=31.1592 folds)	vs play:0.419567
+ AgainstCall(108)=1 from -$81.1731 @ 0
+AgainstRaise(108)=0.419567 from -$74.2955 @ 1
+        Push(108)=1 from $0 @ 0
+ AgainstCall(128)=0.419567 from -$74.2955 @ 1
+AgainstRaise(128)=1 from $0 @ 0
+        Push(128)=1 from $0 @ 0
+OppRAISEChanceR [*] 0 @ $128 ($20 now)	fold -- 0	W(30.6662x)=0.170737 L=0.809981 3o.w_s=(0.562909,0.0204386)
+
+(Fixed at $108)	W(43.0894x)=0.146467 L=0.845289 3o.w_s=(0.55668,0.010254)
+Guaranteed > $0 is in the pot for sure
+OppFoldChance% ...    0   d\0

--- a/holdem/unittests/playlogs.expected/28.txt
+++ b/holdem/unittests/playlogs.expected/28.txt
@@ -1,0 +1,222 @@
+
+==========#28==========
+Playing as ~
+*
+(M) 64.4318%
+(M.w) 63.5088%
+(M.s) 1.8461%
+(M.l) 34.6451%
+(Better All-in) 92.6939%
+(Re.s) 0.244898%
+(Better Mean Rank) 94.6531%
+(Ra.s) 0.571429%
+
+*
+Qh Ac Bet to call 4 (from 0) at 6 pot, 
+Community outcomes (stdev = 0.153491 pcts , avgdev = 0.136252 pcts ), kurtosis = -1.2192
+0.353957 pct: least helpful community
+0.424021 pct: 536 / 19600 (2.73469%)
+0.508776 pct: 6660 / 19600 (33.9796%)
+0.585375 pct: 5307 / 19600 (27.0765%)
+0.644318 pct (mean): mean- 0.648367   mean+ 0.351633 (skew 0.554786 tail right) 
+0.669841 pct: 830 / 19600 (4.23469%)
+0.786498 pct: 853 / 19600 (4.35204%)
+0.854126 pct: 4792 / 19600 (24.449%)
+0.942937 pct: 622 / 19600 (3.17347%)
+0.999972 pct: most helpful community
+CallStrength W(6r)=0.706204 L=0.267746 o.w_s=(0.943673,0.00571429)
+(MinRaise to $8) 	W(38.7918x)=0.277831 L=0.700474 6o.w_s=(0.712153,0.00898056)
+ -  stat_high algb SLIDERX - 
+7 dealt, 6 opp. (round), 6 opp. assumed str., 6 opp. still in
+Choice Optimal 4
+Choice Fold 6
+f(4)=1.053
+CALL 4
+FoldGain()R=0.996793 x 0(=0 folds)	vs play:1.04979
+ AgainstCall(4)=1.01156 from +$3.29077 @ 0.738009
+AgainstRaise(4)=1.03822 from +$30.6385 @ 0.261991
+        Push(4)=1 from $0 @ 0
+ AgainstCall(8)=0.995286 from -$2.79963 @ 0.353579
+AgainstRaise(8)=0.976438 from -$8 @ 0.618494
+        Push(8)=1.0009 from +$6.77398 @ 0.0279265
+OppRAISEChanceR [*] 0.261991 @ $8 ($4 now)	fold -- 0.0279265	W(38.7918x)=0.277831 L=0.700474 6o.w_s=(0.712153,0.00898056)
+OppRAISEChanceR [*] 0.255647 @ $12 ($4 now)	fold -- 0.0838881	W(48.1981x)=0.241344 L=0.732627 6o.w_s=(0.70801,0.0121896)
+OppRAISEChanceR [*] 0.242665 @ $20 ($0 now)	fold -- 0.242519	W(56.9524x)=0.22284 L=0.748125 6o.w_s=(0.705438,0.0145479)
+OppRAISEChanceR [*] 0.215245 @ $36 ($5.18143 now)	fold -- 0.395601	W(69.8419x)=0.208966 L=0.756596 6o.w_s=(0.702671,0.018095)
+OppRAISEChanceR [*] 0.149518 @ $68 ($6.57481 now)	fold -- 0.486043	W(84.9464x)=0.195925 L=0.764843 6o.w_s=(0.699909,0.0216188)
+OppRAISEChanceR [*] 0.0651218 @ $132 ($8.50545 now)	fold -- 0.496876	W(83.4286x)=0.196658 L=0.763974 6o.w_s=(0.699984,0.0216155)
+OppRAISEChanceR [*] 0.00677709 @ $204 ($9.38976 now)	fold -- 0.531722	W(77.1429x)=0.201874 L=0.760555 6o.w_s=(0.701087,0.0202296)
+
+(Fixed at $4)	W(6x)=0.485968 L=0.464946 6o.w_s=(0.722227,0.011676)
+Guaranteed > $0 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+*
+Qh Ac Bet to call 158 (from 4) at 326 pot, 
+Community outcomes (stdev = 0.153491 pcts , avgdev = 0.136252 pcts ), kurtosis = -1.2192
+0.353957 pct: least helpful community
+0.424021 pct: 536 / 19600 (2.73469%)
+0.508776 pct: 6660 / 19600 (33.9796%)
+0.585375 pct: 5307 / 19600 (27.0765%)
+0.644318 pct (mean): mean- 0.648367   mean+ 0.351633 (skew 0.554786 tail right) 
+0.669841 pct: 830 / 19600 (4.23469%)
+0.786498 pct: 853 / 19600 (4.35204%)
+0.854126 pct: 4792 / 19600 (24.449%)
+0.942937 pct: 622 / 19600 (3.17347%)
+0.999972 pct: most helpful community
+CallStrength W(6r)=0.706204 L=0.0986629 o.w_s=(0.84036,0.00571429)
+(MinRaise to $312) 	W(6x)=0.485968 L=0.464946 2o.w_s=(0.583244,0.028747)
+ -  stat_high algb SLIDERX - 
+7 dealt, 6 opp. (round), 6 opp. assumed str., 2 opp. still in
+Choice Optimal 158
+Choice Fold 210
+f(158)=2.0278
+CALL 158
+FoldGain()R=0.980952 x 0(=0 folds)	vs play:2.00875
+ AgainstCall(158)=1 from +$211.838 @ 0
+AgainstRaise(158)=2.00875 from +$211.838 @ 1
+        Push(158)=1 from $0 @ 0
+ AgainstCall(210)=1.39582 from +$83.1225 @ 1
+AgainstRaise(210)=1 from $0 @ 0
+        Push(210)=1 from $0 @ 0
+OppRAISEChanceR [*] 0 @ $204 ($46 now)	fold -- 0	W(6x)=0.485968 L=0.464946 2o.w_s=(0.583244,0.028747)
+
+(Fixed at $158)	W(6x)=0.485968 L=0.464946 2o.w_s=(0.583244,0.028747)
+Guaranteed > $6 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+3d 5d 9s community
+*
+(M) 49.3196%
+(M.w) 48.7322%
+(M.s) 1.17474%
+(M.l) 50.0931%
+(Better All-in) 54.1166%
+(Re.s) 0.370028%
+(Better Mean Rank) 53.2313%
+(Ra.s) 0%
+
+*
+Qh Ac Bet to call 0 (from 0) at 480 pot, 
+Community outcomes (stdev = 0.137398 pcts , avgdev = 0.10259 pcts ), kurtosis = 1.54379
+0.335946 pct: least helpful community
+0.384732 pct: 14 / 47 (29.7872%)
+0.446228 pct: 19 / 47 (40.4255%)
+0.493196 pct (mean): mean- 0.702128   mean+ 0.297872 (skew 1.60423 tail right) 
+0.55091 pct: 8 / 47 (17.0213%)
+0.59882 pct: 0 / 47 (0%)
+0.673926 pct: 0 / 47 (0%)
+0.75874 pct: 2 / 47 (4.25532%)
+0.847711 pct: 4 / 47 (8.51064%)
+0.861693 pct: most helpful community
+CallStrength W(2r)=0.283357 L=0.716643 o.w_s=(0.532313,0)
+(MinRaise to $4) 	W(2x)=0.236818 L=0.745313 2o.w_s=(0.488769,0.0181053)
+ -  stat_high algb SLIDERX - 
+7 dealt, 2 opp. (round), 2 opp. assumed str., 2 opp. still in
+Choice Optimal 0
+Choice Fold 52
+f(0)=4.61015
+CALL 0
+FoldGain()R=0 x 0(=0 folds)	vs play:3.61015
+ AgainstCall(0)=3.55012 from +$136.011 @ 0.974964
+AgainstRaise(0)=1.06003 from +$124.677 @ 0.0250356
+        Push(0)=1 from $0 @ 0
+ AgainstCall(4)=3.17756 from +$115.939 @ 0.976664
+AgainstRaise(4)=1.0468 from +$104.293 @ 0.0233358
+        Push(4)=1 from $0 @ 0
+OppRAISEChanceR [*] 0.0250356 @ $4 ($4 now)	fold -- 0	W(2x)=0.236818 L=0.745313 2o.w_s=(0.488769,0.0181053)
+OppRAISEChanceR [*] 0.0242038 @ $8 ($4 now)	fold -- 0	W(2x)=0.236818 L=0.745313 2o.w_s=(0.488769,0.0181053)
+OppRAISEChanceR [*] 0.0222053 @ $16 ($4.58975 now)	fold -- 0	W(2x)=0.236818 L=0.745313 2o.w_s=(0.488769,0.0181053)
+OppRAISEChanceR [*] 0.017518 @ $32 ($6.29291 now)	fold -- 0	W(2x)=0.236818 L=0.745313 2o.w_s=(0.488769,0.0181053)
+OppRAISEChanceR [*] 0 @ $52 ($7.73332 now)	fold -- 0	W(2x)=0.236818 L=0.745313 2o.w_s=(0.488769,0.0181053)
+
+(Fixed at $0)	W(2x)=0.236818 L=0.745313 2o.w_s=(0.488769,0.0181053)
+Guaranteed > $480 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+3d 5d 9s Td community
+*
+(M) 38.7132%
+(M.w) 38.3663%
+(M.s) 0.693895%
+(M.l) 60.9398%
+(Better All-in) 44.4444%
+(Re.s) 0.386473%
+(Better Mean Rank) 31.6489%
+(Ra.s) 0%
+
+*
+Qh Ac Bet to call 0 (from 0) at 480 pot, 
+Community outcomes (stdev = 0.168132 pcts , avgdev = 0.128132 pcts ), kurtosis = 1.58654
+0.177778 pct: least helpful community
+0.19596 pct: 8 / 46 (17.3913%)
+0.319625 pct: 21 / 46 (45.6522%)
+0.387132 pct (mean): mean- 0.630435   mean+ 0.369565 (skew 1.34435 tail right) 
+0.413889 pct: 0 / 46 (0%)
+0.477467 pct: 13 / 46 (28.2609%)
+0.602778 pct: 0 / 46 (0%)
+0.697222 pct: 0 / 46 (0%)
+0.830303 pct: 4 / 46 (8.69565%)
+0.838889 pct: most helpful community
+CallStrength W(2c)=0.175017 L=0.819607 o.w_s=(0.383663,0.00693895)
+(MinRaise to $4) 	W(2x)=0.0826965 L=0.917303 2o.w_s=(0.37919,2.19591e-16)
+ -  stat_high algb SLIDERX - 
+7 dealt, 2 opp. (round), 2 opp. assumed str., 2 opp. still in
+Choice Optimal 0
+Choice Fold 52
+f(0)=3.6125
+CALL 0
+FoldGain()R=0 x 0(=0 folds)	vs play:2.6125
+ AgainstCall(0)=2.51797 from +$85.2937 @ 0.925442
+AgainstRaise(0)=1.09453 from +$65.9312 @ 0.0745576
+        Push(0)=1 from $0 @ 0
+ AgainstCall(4)=1.64821 from +$36.3559 @ 0.927142
+AgainstRaise(4)=1.02011 from +$14.3496 @ 0.0728578
+        Push(4)=1 from $0 @ 0
+OppRAISEChanceR [*] 0.0745576 @ $4 ($4 now)	fold -- 0	W(2x)=0.0826965 L=0.917303 2o.w_s=(0.37919,2.19591e-16)
+OppRAISEChanceR [*] 0.0737258 @ $8 ($0 now)	fold -- 0	W(2x)=0.0826965 L=0.917303 2o.w_s=(0.37919,2.19591e-16)
+OppRAISEChanceR [*] 0.0717273 @ $16 ($6.2462 now)	fold -- 0	W(2x)=0.0826965 L=0.917303 2o.w_s=(0.37919,2.19591e-16)
+OppRAISEChanceR [*] 0.0670401 @ $32 ($9.48705 now)	fold -- 0	W(2x)=0.0826965 L=0.917303 2o.w_s=(0.37919,2.19591e-16)
+OppRAISEChanceR [*] 0 @ $52 ($13.4348 now)	fold -- 0	W(2x)=0.0826965 L=0.917303 2o.w_s=(0.37919,2.19591e-16)
+
+(Fixed at $0)	W(2x)=0.0826965 L=0.917303 2o.w_s=(0.37919,2.19591e-16)
+Guaranteed > $480 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+3d 5d 6s 9s Td community
+*
+(M) 30.8081%
+(M.w) 30.404%
+(M.s) 0.808081%
+(M.l) 68.7879%
+(Better All-in) 30.8081%
+(Re.s) 0.808081%
+(Better Mean Rank) 30.5273%
+(Ra.s) 0%
+
+*
+Qh Ac Bet to call 0 (from 0) at 480 pot, 
+CallStrength W(2r)=0.0931915 L=0.906808 o.w_s=(0.305273,0)
+(MinRaise to $4) 	W(2x)=0 L=1 2o.w_s=(0,0)
+ -  stat_high algb SLIDERX - 
+7 dealt, 2 opp. (round), 2 opp. assumed str., 2 opp. still in
+Choice Optimal 0
+Choice Fold 2
+f(0)=2.68056
+CALL 0
+FoldGain()R=0 x 0(=0 folds)	vs play:1.68056
+ AgainstCall(0)=1.5476 from +$44.7319 @ 0.636575
+AgainstRaise(0)=1.13295 from +$19.0236 @ 0.363425
+        Push(0)=1 from $0 @ 0
+ AgainstCall(4)=0.950902 from -$4 @ 0.638275
+AgainstRaise(4)=0.779688 from -$31.6711 @ 0.361725
+        Push(4)=1 from $0 @ 0
+OppRAISEChanceR [*] 0.363425 @ $4 ($0 now)	fold -- 0	W(2x)=0 L=1 2o.w_s=(0,0)
+OppRAISEChanceR [*] 0.362593 @ $8 ($0 now)	fold -- 0	W(2x)=0 L=1 2o.w_s=(0,0)
+OppRAISEChanceR [*] 0.360594 @ $16 ($0 now)	fold -- 0	W(2x)=0 L=1 2o.w_s=(0,0)
+OppRAISEChanceR [*] 0.355907 @ $32 ($0 now)	fold -- 0	W(2x)=0 L=1 2o.w_s=(0,0)
+OppRAISEChanceR [*] 0 @ $52 ($0 now)	fold -- 0	W(2x)=0 L=1 2o.w_s=(0,0)
+
+(Fixed at $0)	W(2x)=0 L=1 2o.w_s=(0,0)
+Guaranteed > $480 is in the pot for sure
+OppFoldChance% ...    0   d\0

--- a/holdem/unittests/playlogs.expected/4.txt
+++ b/holdem/unittests/playlogs.expected/4.txt
@@ -1,0 +1,380 @@
+
+==========#4==========
+Playing as ~
+*
+(M) 66.2089%
+(M.w) 65.3137%
+(M.s) 1.79033%
+(M.l) 32.896%
+(Better All-in) 93.5102%
+(Re.s) 0.244898%
+(Better Mean Rank) 96.2041%
+(Ra.s) 0.244898%
+
+*
+Qs As Bet to call 2 (from 0) at 3 pot, 
+Community outcomes (stdev = 0.152984 pcts , avgdev = 0.136737 pcts ), kurtosis = -1.24503
+0.353957 pct: least helpful community
+0.421885 pct: 630 / 19600 (3.21429%)
+0.506467 pct: 4926 / 19600 (25.1327%)
+0.580509 pct: 5019 / 19600 (25.6071%)
+0.662089 pct (mean): mean- 0.568929   mean+ 0.431071 (skew 0.348953 tail right) 
+0.684149 pct: 2180 / 19600 (11.1224%)
+0.771406 pct: 1437 / 19600 (7.33163%)
+0.853498 pct: 4431 / 19600 (22.6071%)
+0.942588 pct: 977 / 19600 (4.98469%)
+1 pct: most helpful community
+CallStrength W(5r)=0.818845 L=0.170666 o.w_s=(0.960816,0.00244898)
+(MinRaise to $4) 	W(38.4911x)=0.317925 L=0.661304 5o.w_s=(0.688789,0.00877377)
+ -  statranking algb RAW - 
+9 dealt, 8 opp. (round), 5 opp. assumed str., 5 opp. still in
+Choice Optimal 2
+Choice Fold 2
+f(2)=1.00006
+CALL 2
+FoldGain()R=0.999816 x 0(=0 folds)	vs play:0.999876
+ AgainstCall(2)=1.00063 from +$2.19943 @ 0.431709
+AgainstRaise(2)=0.999246 from -$2 @ 0.568291
+        Push(2)=1 from $0 @ 0
+ AgainstCall(4)=0.999677 from -$1.02055 @ 0.476993
+AgainstRaise(4)=0.998698 from -$4 @ 0.490346
+        Push(4)=1.00007 from +$3.30754 @ 0.0326606
+OppRAISEChanceR [*] 0.287615 @ $4 ($2 now)	fold -- 0.0326606	W(38.4911x)=0.317925 L=0.661304 5o.w_s=(0.688789,0.00877377)
+OppRAISEChanceR [*] 0.287309 @ $6 ($2 now)	fold -- 0.100656	W(42.8954x)=0.302024 L=0.675289 5o.w_s=(0.686868,0.0100222)
+OppRAISEChanceR [F] 0.568291 @ $10 ($0 now)	fold -- 0.317926	W(50.5171x)=0.27487 L=0.699209 5o.w_s=(0.683301,0.0124271)
+OppRAISEChanceR [F] 0.398504 @ $18 ($2.59072 now)	fold -- 0.449608	W(62.6792x)=0.259804 L=0.71029 5o.w_s=(0.680715,0.0149959)
+OppRAISEChanceR [F] 0.246725 @ $34 ($3.28741 now)	fold -- 0.55436	W(80.5401x)=0.24395 L=0.71889 5o.w_s=(0.677177,0.019477)
+OppRAISEChanceR [F] 0.138213 @ $66 ($4.25272 now)	fold -- 0.648367	W(106.988x)=0.23131 L=0.733087 5o.w_s=(0.67566,0.0196258)
+OppRAISEChanceR [F] 0.0717361 @ $130 ($5.07774 now)	fold -- 0.715891	W(146.281x)=0.214114 L=0.75348 5o.w_s=(0.673699,0.0192601)
+OppRAISEChanceR [F] 0.0345249 @ $258 ($6.14688 now)	fold -- 0.781259	W(203.502x)=0.192872 L=0.779702 5o.w_s=(0.67133,0.0180903)
+OppRAISEChanceR [F] 0.0188013 @ $514 ($7.62596 now)	fold -- 0.823496	W(265.682x)=0.170493 L=0.806635 5o.w_s=(0.668414,0.0170426)
+OppRAISEChanceR [F] 0.00468915 @ $1026 ($8.92693 now)	fold -- 0.854768	W(357.213x)=0.13756 L=0.846256 5o.w_s=(0.663496,0.0149251)
+OppRAISEChanceR [F] 0 @ $1507 ($9.98592 now)	fold -- 0.867547	W(328.225x)=0.14799 L=0.833708 5o.w_s=(0.665146,0.0156936)
+
+(Fixed at $2)	W(5x)=0.53412 L=0.426433 5o.w_s=(0.702778,0.010087)
+Guaranteed > $0 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+*
+Qs As Bet to call 5 (from 2) at 8 pot, 
+Community outcomes (stdev = 0.152984 pcts , avgdev = 0.136737 pcts ), kurtosis = -1.24503
+0.353957 pct: least helpful community
+0.421885 pct: 630 / 19600 (3.21429%)
+0.506467 pct: 4926 / 19600 (25.1327%)
+0.580509 pct: 5019 / 19600 (25.6071%)
+0.662089 pct (mean): mean- 0.568929   mean+ 0.431071 (skew 0.348953 tail right) 
+0.684149 pct: 2180 / 19600 (11.1224%)
+0.771406 pct: 1437 / 19600 (7.33163%)
+0.853498 pct: 4431 / 19600 (22.6071%)
+0.942588 pct: 977 / 19600 (4.98469%)
+1 pct: most helpful community
+CallStrength W(5m)=0.53412 L=0.426433 o.w_s=(0.53412,0.0394473)
+(MinRaise to $8) 	W(5x)=0.53412 L=0.426433 1o.w_s=(0.53412,0.0394473)
+ -  statranking algb RAW - 
+9 dealt, 8 opp. (round), 5 opp. assumed str., 1 opp. still in
+Choice Optimal 5
+Choice Fold 12
+f(5)=1.00162
+CALL 5
+FoldGain()R=0.998673 x 0(=0 folds)	vs play:1.00029
+ AgainstCall(5)=1.00065 from +$1.09228 @ 0.892138
+AgainstRaise(5)=0.999642 from -$5 @ 0.107862
+        Push(5)=1 from $0 @ 0
+ AgainstCall(8)=1.00049 from +$1.41533 @ 0.526565
+AgainstRaise(8)=0.998401 from -$5.08856 @ 0.473435
+        Push(8)=1 from $0 @ 0
+OppRAISEChanceR [*] 0 @ $8 ($3 now)	fold -- 0	W(5x)=0.53412 L=0.426433 1o.w_s=(0.53412,0.0394473)
+OppRAISEChanceR [*] 0 @ $13 ($3 now)	fold -- 0.0617284	W(5x)=0.53412 L=0.426433 1o.w_s=(0.53412,0.0394473)
+OppRAISEChanceR [*] 0 @ $21 ($3.31928 now)	fold -- 0.192027	W(5.16667x)=0.530585 L=0.4288 1o.w_s=(0.530585,0.0406149)
+OppRAISEChanceR [*] 0 @ $37 ($4.25886 now)	fold -- 0.542365	W(6.27778x)=0.507712 L=0.444043 1o.w_s=(0.507712,0.0482449)
+OppRAISEChanceR [*] 0 @ $69 ($5.44583 now)	fold -- 0.673419	W(8.22222x)=0.470661 L=0.467702 1o.w_s=(0.470661,0.0616367)
+OppRAISEChanceR [F] 0.107862 @ $133 ($6.69902 now)	fold -- 0.781442	W(11x)=0.42158 L=0.49758 1o.w_s=(0.42158,0.0808397)
+OppRAISEChanceR [F] 0.0568357 @ $261 ($8.2998 now)	fold -- 0.851003	W(15.1667x)=0.401057 L=0.558847 1o.w_s=(0.401057,0.0400966)
+OppRAISEChanceR [F] 0.0281667 @ $517 ($9.92407 now)	fold -- 0.901402	W(21x)=0.387904 L=0.598877 1o.w_s=(0.387904,0.0132191)
+OppRAISEChanceR [F] 0.0128582 @ $1029 ($12.0128 now)	fold -- 0.932766	W(29.0556x)=0.354011 L=0.629299 1o.w_s=(0.354011,0.0166895)
+OppRAISEChanceR [F] 0 @ $1507 ($13.3134 now)	fold -- 0.945866	W(35.1667x)=0.330066 L=0.650638 1o.w_s=(0.330066,0.019296)
+
+(Fixed at $5)	W(5x)=0.53412 L=0.426433 1o.w_s=(0.53412,0.0394473)
+Guaranteed > $1 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+6d Jd Qc community
+*
+(M) 82.7498%
+(M.w) 82.3647%
+(M.s) 0.770144%
+(M.l) 16.8651%
+(Better All-in) 95.7447%
+(Re.s) 0.185014%
+(Better Mean Rank) 97.534%
+(Ra.s) 0%
+
+*
+Qs As Bet to call 0 (from 0) at 11 pot, 
+Community outcomes (stdev = 0.0535551 pcts , avgdev = 0.043572 pcts ), kurtosis = 0.19345
+0.693489 pct: least helpful community
+0.710471 pct: 3 / 47 (6.38298%)
+0.761337 pct: 5 / 47 (10.6383%)
+0.789405 pct: 8 / 47 (17.0213%)
+0.826545 pct: 7 / 47 (14.8936%)
+0.827498 pct (mean): (skew -0.33243 tail left) mean- 0.404255   mean+ 0.595745
+0.859826 pct: 21 / 47 (44.6809%)
+0.917369 pct: 2 / 47 (4.25532%)
+0.962165 pct: 1 / 47 (2.12766%)
+0.962165 pct: most helpful community
+CallStrength W(1m)=0.823647 L=0.168651 o.w_s=(0.823647,0.00770144)
+(MinRaise to $2) 	W(1x)=0.823647 L=0.168651 1o.w_s=(0.823647,0.00770144)
+ -  statranking algb RAW - 
+9 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 0
+Choice Fold 35
+f(0)=1.0089
+CALL 0
+FoldGain()M=0.996671 x 0(=0 folds)	vs play:1.00557
+ AgainstCall(0)=1.00557 from +$9.10248 @ 0.919189
+AgainstRaise(0)=1 from $0 @ 0.0808111
+        Push(0)=1 from $0 @ 0
+ AgainstCall(2)=1.00357 from +$10.4125 @ 0.515599
+AgainstRaise(2)=1.00029 from +$0.907585 @ 0.484401
+        Push(2)=1 from $0 @ 0
+OppRAISEChanceM [*] 0 @ $2 ($2 now)	fold -- 0	W(1x)=0.823647 L=0.168651 1o.w_s=(0.823647,0.00770144)
+OppRAISEChanceM [*] 0 @ $4 ($2 now)	fold -- 0	W(1x)=0.823647 L=0.168651 1o.w_s=(0.823647,0.00770144)
+OppRAISEChanceM [*] 0 @ $8 ($2.29487 now)	fold -- 0.188646	W(1x)=0.823647 L=0.168651 1o.w_s=(0.823647,0.00770144)
+OppRAISEChanceM [*] 0 @ $16 ($3.14645 now)	fold -- 0.369239	W(5x)=0.570687 L=0.401808 1o.w_s=(0.570687,0.0275045)
+OppRAISEChanceM [*] 0 @ $32 ($4.23062 now)	fold -- 0.577434	W(6.5x)=0.512516 L=0.451728 1o.w_s=(0.512516,0.0357558)
+OppRAISEChanceM [*] 0 @ $64 ($5.71983 now)	fold -- 0.759805	W(8.16667x)=0.457289 L=0.498298 1o.w_s=(0.457289,0.044413)
+OppRAISEChanceM [F] 0.0808111 @ $128 ($7.28128 now)	fold -- 0.833676	W(10.8333x)=0.394118 L=0.548232 1o.w_s=(0.394118,0.0576494)
+OppRAISEChanceM [F] 0.0390002 @ $256 ($9.39388 now)	fold -- 0.880555	W(14.5x)=0.318315 L=0.604524 1o.w_s=(0.318315,0.0771615)
+OppRAISEChanceM [F] 0.0190621 @ $512 ($12.0496 now)	fold -- 0.912436	W(20x)=0.222403 L=0.672277 1o.w_s=(0.222403,0.10532)
+OppRAISEChanceM [F] 0.00863876 @ $1024 ($15.2737 now)	fold -- 0.938551	W(27.6667x)=0.178249 L=0.802258 1o.w_s=(0.178249,0.0194925)
+OppRAISEChanceM [F] 0 @ $1502 ($17.5429 now)	fold -- 0.943459	W(33.1667x)=0.162839 L=0.834411 1o.w_s=(0.162839,0.00275029)
+
+(Fixed at $0)	W(1x)=0.823647 L=0.168651 1o.w_s=(0.823647,0.00770144)
+Guaranteed > $11 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+6d Ts Jd Qc community
+*
+(M) 81.1781%
+(M.w) 80.3667%
+(M.s) 1.62275%
+(M.l) 18.0105%
+(Better All-in) 89.2271%
+(Re.s) 0.483092%
+(Better Mean Rank) 93.0851%
+(Ra.s) 0%
+
+*
+Qs As Bet to call 0 (from 0) at 11 pot, 
+Community outcomes (stdev = 0.0925727 pcts , avgdev = 0.0651415 pcts ), kurtosis = 1.73412
+0.54798 pct: least helpful community
+0.568056 pct: 4 / 46 (8.69565%)
+0.631097 pct: 0 / 46 (0%)
+0.703662 pct: 4 / 46 (8.69565%)
+0.763636 pct: 1 / 46 (2.17391%)
+0.806439 pct: 8 / 46 (17.3913%)
+0.811781 pct (mean): (skew -1.47932 tail left) mean- 0.369565   mean+ 0.630435
+0.848353 pct: 23 / 46 (50%)
+0.921296 pct: 6 / 46 (13.0435%)
+0.935859 pct: most helpful community
+CallStrength W(1m)=0.803667 L=0.180105 o.w_s=(0.803667,0.0162275)
+(MinRaise to $2) 	W(1x)=0.803667 L=0.180105 1o.w_s=(0.803667,0.0162275)
+ -  statranking algb RAW - 
+9 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 0
+Choice Fold 26
+f(0)=1.0083
+CALL 0
+FoldGain()M=0.996671 x 0(=0 folds)	vs play:1.00497
+ AgainstCall(0)=1.00497 from +$8.92959 @ 0.836555
+AgainstRaise(0)=1 from $0 @ 0.163445
+        Push(0)=1 from $0 @ 0
+ AgainstCall(2)=1.00355 from +$10.1767 @ 0.523767
+AgainstRaise(2)=0.999479 from -$1.64353 @ 0.476233
+        Push(2)=1 from $0 @ 0
+OppRAISEChanceM [*] 0 @ $2 ($2 now)	fold -- 2.53542e-18	W(1x)=0.803667 L=0.180105 1o.w_s=(0.803667,0.0162275)
+OppRAISEChanceM [*] 0 @ $4 ($0 now)	fold -- 2.53542e-18	W(1x)=0.803667 L=0.180105 1o.w_s=(0.803667,0.0162275)
+OppRAISEChanceM [*] 0 @ $8 ($3.1231 now)	fold -- 0.202594	W(1x)=0.803667 L=0.180105 1o.w_s=(0.803667,0.0162275)
+OppRAISEChanceM [*] 0 @ $16 ($4.74352 now)	fold -- 0.415175	W(5x)=0.413483 L=0.550615 1o.w_s=(0.413483,0.0359025)
+OppRAISEChanceM [F] 0.163445 @ $32 ($7.0612 now)	fold -- 0.670567	W(6.5x)=0.298891 L=0.654436 1o.w_s=(0.298891,0.0466733)
+OppRAISEChanceM [F] 0.0995758 @ $64 ($10.3593 now)	fold -- 0.760049	W(8.16667x)=0.1892 L=0.756463 1o.w_s=(0.1892,0.0543368)
+OppRAISEChanceM [F] 0.0527152 @ $128 ($15.0598 now)	fold -- 0.84886	W(10.8333x)=0.125476 L=0.863106 1o.w_s=(0.125476,0.0114185)
+OppRAISEChanceM [F] 0.0254911 @ $256 ($21.8928 now)	fold -- 0.895153	W(14.5x)=0.0779425 L=0.906774 1o.w_s=(0.0779425,0.0152833)
+OppRAISEChanceM [F] 0.00957689 @ $512 ($31.0154 now)	fold -- 0.914414	W(20x)=0.0605996 L=0.920064 1o.w_s=(0.0605996,0.0193366)
+OppRAISEChanceM [F] 0.00432875 @ $1024 ($44.3436 now)	fold -- 0.928276	W(27.6667x)=0.0505184 L=0.925808 1o.w_s=(0.0505184,0.0236741)
+OppRAISEChanceM [F] 0 @ $1502 ($54.0134 now)	fold -- 0.933199	W(33.1667x)=0.0432862 L=0.929928 1o.w_s=(0.0432862,0.0267858)
+
+(Fixed at $0)	W(1x)=0.803667 L=0.180105 1o.w_s=(0.803667,0.0162275)
+Guaranteed > $11 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+5h 6d Ts Jd Qc community
+*
+(M) 85.1515%
+(M.w) 84.8485%
+(M.s) 0.606061%
+(M.l) 14.5455%
+(Better All-in) 85.1515%
+(Re.s) 0.606061%
+(Better Mean Rank) 85.2914%
+(Ra.s) 0%
+
+*
+Qs As Bet to call 10 (from 0) at 21 pot, 
+CallStrength W(1m)=0.848485 L=0.145455 o.w_s=(0.848485,0.00606061)
+(MinRaise to $20) 	W(1x)=0.848485 L=0.145455 1o.w_s=(0.848485,0.00606061)
+ -  statranking algb RAW - 
+9 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 21
+Choice Fold 53
+f(10)=1.01425
+*MinRaise 20
+RAISETO 21
+
+FoldGain()M=0.996671 x 0(=0 folds)	vs play:1.01099
+ AgainstCall(21)=1.00789 from +$24.1303 @ 0.49082
+AgainstRaise(21)=1.00311 from +$9.16677 @ 0.50918
+        Push(21)=1 from $0 @ 0
+ AgainstCall(10)=1.01092 from +$16.397 @ 1
+AgainstRaise(10)=1 from $0 @ 0
+        Push(10)=1 from $0 @ 0
+
+Why didn't I call?
+OppRAISEChanceM [*] 0 @ $20 ($0 now)	fold -- 0	W(1x)=0.848485 L=0.145455 1o.w_s=(0.848485,0.00606061)
+OppRAISEChanceM [*] 0 @ $30 ($0 now)	fold -- 0.126751	W(1x)=0.848485 L=0.145455 1o.w_s=(0.848485,0.00606061)
+OppRAISEChanceM [*] 0 @ $50 ($0 now)	fold -- 0.433692	W(1x)=0.848485 L=0.145455 1o.w_s=(0.848485,0.00606061)
+OppRAISEChanceM [F] 0 @ $90 ($0 now)	fold -- 0.621684	W(6x)=0.0909091 L=0.872727 1o.w_s=(0.0909091,0.0363636)
+OppRAISEChanceM [F] 0 @ $170 ($0 now)	fold -- 0.75308	W(7.83333x)=0 L=1 1o.w_s=(0,0)
+OppRAISEChanceM [F] 0 @ $330 ($0 now)	fold -- 0.827374	W(10.3333x)=0 L=1 1o.w_s=(0,0)
+OppRAISEChanceM [F] 0 @ $650 ($0 now)	fold -- 0.867441	W(14x)=0 L=1 1o.w_s=(0,0)
+OppRAISEChanceM [F] 0 @ $1290 ($0 now)	fold -- 0.893255	W(19.1667x)=0 L=1 1o.w_s=(0,0)
+OppRAISEChanceM [F] 0 @ $1502 ($0 now)	fold -- 0.896909	W(20.5x)=0 L=1 1o.w_s=(0,0)
+
+(Fixed at $21)	W(1x)=0.848485 L=0.145455 1o.w_s=(0.848485,0.00606061)
+	--
+What am I expecting now, given my actual bet?
+OppRAISEChanceM [*] 0.50918 @ $31 ($0 now)
+OppRAISEChanceM [*] 0.508295 @ $52 ($0 now)
+OppRAISEChanceM [F] 0.279467 @ $94 ($0 now)
+OppRAISEChanceM [F] 0.198659 @ $178 ($0 now)
+OppRAISEChanceM [F] 0.140017 @ $346 ($0 now)
+OppRAISEChanceM [F] 0.0680248 @ $682 ($0 now)
+OppRAISEChanceM [F] 0.0301143 @ $1354 ($0 now)
+OppRAISEChanceM [F] 0 @ $1502 ($0 now)
+Guaranteed > $11 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+*
+Qs As Bet to call 32 (from 21) at 64 pot, 
+CallStrength W(1m)=0.848485 L=0.145455 o.w_s=(0.848485,0.00606061)
+(MinRaise to $43) 	W(1x)=0.848485 L=0.145455 1o.w_s=(0.848485,0.00606061)
+ -  statranking algb RAW - 
+9 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 43
+Choice Fold 141
+f(32)=1.03852
+*MinRaise 43
+RAISETO 43
+
+FoldGain()M=0.98269 x 0(=0 folds)	vs play:1.02262
+ AgainstCall(43)=1.01389 from +$39.597 @ 0.526925
+AgainstRaise(43)=1.00872 from +$27.6981 @ 0.473075
+        Push(43)=1 from $0 @ 0
+ AgainstCall(32)=1.02121 from +$31.8636 @ 1
+AgainstRaise(32)=1 from $0 @ 0
+        Push(32)=1 from $0 @ 0
+
+Why didn't I call?
+OppRAISEChanceM [*] 0 @ $43 ($0 now)	fold -- 0	W(1x)=0.848485 L=0.145455 1o.w_s=(0.848485,0.00606061)
+OppRAISEChanceM [*] 0 @ $75 ($0 now)	fold -- 0.0649121	W(1x)=0.848485 L=0.145455 1o.w_s=(0.848485,0.00606061)
+OppRAISEChanceM [*] 0 @ $118 ($0 now)	fold -- 0.35697	W(1x)=0.848485 L=0.145455 1o.w_s=(0.848485,0.00606061)
+OppRAISEChanceM [F] 0 @ $204 ($0 now)	fold -- 0.57676	W(5.83333x)=0.116162 L=0.848485 1o.w_s=(0.116162,0.0353535)
+OppRAISEChanceM [F] 0 @ $376 ($0 now)	fold -- 0.726907	W(7.33333x)=0 L=1 1o.w_s=(0,0)
+OppRAISEChanceM [F] 0 @ $720 ($0 now)	fold -- 0.822719	W(9.83333x)=0 L=1 1o.w_s=(0,0)
+OppRAISEChanceM [F] 0 @ $1408 ($0 now)	fold -- 0.874162	W(13.3333x)=0 L=1 1o.w_s=(0,0)
+OppRAISEChanceM [F] 0 @ $1502 ($0 now)	fold -- 0.877461	W(13.6667x)=0 L=1 1o.w_s=(0,0)
+
+(Fixed at $43)	W(1x)=0.848485 L=0.145455 1o.w_s=(0.848485,0.00606061)
+	--
+What am I expecting now, given my actual bet?
+OppRAISEChanceM [*] 0.473075 @ $54 ($0 now)
+OppRAISEChanceM [*] 0.471731 @ $86 ($0 now)
+OppRAISEChanceM [*] 0.469462 @ $140 ($0 now)
+OppRAISEChanceM [F] 0.250164 @ $248 ($0 now)
+OppRAISEChanceM [F] 0.176205 @ $464 ($0 now)
+OppRAISEChanceM [F] 0.107054 @ $896 ($0 now)
+OppRAISEChanceM [F] 0 @ $1502 ($0 now)
+Guaranteed > $11 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+*
+Qs As Bet to call 54 (from 43) at 108 pot, 
+CallStrength W(1m)=0.848485 L=0.145455 o.w_s=(0.848485,0.00606061)
+(MinRaise to $65) 	W(1x)=0.848485 L=0.145455 1o.w_s=(0.848485,0.00606061)
+ -  statranking algb RAW - 
+9 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 72
+Choice Fold 229
+f(54)=1.06347
+*MinRaise 65
+RAISETO 72
+
+FoldGain()M=0.968043 x 0(=0 folds)	vs play:1.033
+ AgainstCall(72)=1.02118 from +$59.9848 @ 0.53025
+AgainstRaise(72)=1.01182 from +$37.8062 @ 0.46975
+        Push(72)=1 from $0 @ 0
+ AgainstCall(54)=1.03151 from +$47.3303 @ 1
+AgainstRaise(54)=1 from $0 @ 0
+        Push(54)=1 from $0 @ 0
+
+Why didn't I call?
+OppRAISEChanceM [*] 0 @ $65 ($0 now)	fold -- 0	W(1x)=0.848485 L=0.145455 1o.w_s=(0.848485,0.00606061)
+OppRAISEChanceM [*] 0 @ $119 ($0 now)	fold -- 0.0368493	W(1x)=0.848485 L=0.145455 1o.w_s=(0.848485,0.00606061)
+OppRAISEChanceM [*] 0 @ $184 ($0 now)	fold -- 0.338953	W(1x)=0.848485 L=0.145455 1o.w_s=(0.848485,0.00606061)
+OppRAISEChanceM [F] 0 @ $314 ($0 now)	fold -- 0.54423	W(6x)=0.0909091 L=0.872727 1o.w_s=(0.0909091,0.0363636)
+OppRAISEChanceM [F] 0 @ $574 ($0 now)	fold -- 0.71662	W(7.16667x)=0 L=1 1o.w_s=(0,0)
+OppRAISEChanceM [F] 0 @ $1094 ($0 now)	fold -- 0.819346	W(9.66667x)=0 L=1 1o.w_s=(0,0)
+OppRAISEChanceM [F] 0 @ $1502 ($0 now)	fold -- 0.850027	W(11x)=0 L=1 1o.w_s=(0,0)
+
+(Fixed at $72)	W(1x)=0.848485 L=0.145455 1o.w_s=(0.848485,0.00606061)
+	--
+What am I expecting now, given my actual bet?
+OppRAISEChanceM [*] 0.46975 @ $83 ($0 now)
+OppRAISEChanceM [*] 0.467489 @ $137 ($0 now)
+OppRAISEChanceM [*] 0.464011 @ $220 ($0 now)
+OppRAISEChanceM [F] 0.249433 @ $386 ($0 now)
+OppRAISEChanceM [F] 0.173888 @ $718 ($0 now)
+OppRAISEChanceM [F] 0.0984033 @ $1382 ($0 now)
+OppRAISEChanceM [F] 0 @ $1502 ($0 now)
+Guaranteed > $11 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+*
+Qs As Bet to call 347 (from 72) at 430 pot, 
+CallStrength W(1m)=0.848485 L=0.145455 o.w_s=(0.848485,0.00606061)
+(MinRaise to $622) 	W(1x)=0.848485 L=0.145455 1o.w_s=(0.848485,0.00606061)
+ -  statranking algb RAW - 
+9 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 968
+Choice Fold 968
+f(347)=1.05802
+*MinRaise 622
+RAISETO 968
+
+FoldGain()M=1.11064 x 49.3333(=7.25624 folds)	vs play:1.44246
+ AgainstCall(968)=1.20912 from +$689.9 @ 0.455275
+AgainstRaise(968)=1.17397 from +$883.233 @ 0.29585
+        Push(968)=1.05938 from +$358.34 @ 0.248875
+ AgainstCall(347)=1.16865 from +$253.318 @ 1
+AgainstRaise(347)=1 from $0 @ 0
+        Push(347)=1 from $0 @ 0
+
+Why didn't I call?
+OppRAISEChanceM [*] 0 @ $622 ($0 now)	fold -- 0	W(1x)=0.848485 L=0.145455 1o.w_s=(0.848485,0.00606061)
+OppRAISEChanceM [*] 0 @ $969 ($0 now)	fold -- 0.249481	W(1x)=0.848485 L=0.145455 1o.w_s=(0.848485,0.00606061)
+OppRAISEChanceM [F] 0 @ $1502 ($0 now)	fold -- 0.461933	W(5.16667x)=0.217172 L=0.751515 1o.w_s=(0.217172,0.0313131)
+
+(Fixed at $968)	W(1x)=0.848485 L=0.145455 1o.w_s=(0.848485,0.00606061)
+Guaranteed > $11 is in the pot for sure
+OppFoldChance% ...    0.248875   d\0.000514574
+if playstyle is Danger/Conservative, overall utility is 0.331828

--- a/holdem/unittests/playlogs.expected/5.txt
+++ b/holdem/unittests/playlogs.expected/5.txt
@@ -1,0 +1,236 @@
+
+==========#5==========
+Playing as ~
+*
+(M) 40.512%
+(M.w) 37.6747%
+(M.s) 5.67457%
+(M.l) 56.6507%
+(Better All-in) 15.0612%
+(Re.s) 0.244898%
+(Better Mean Rank) 19.1429%
+(Ra.s) 0.571429%
+
+*
+5c 7d Bet to call 10.125 (from 10.125) at 25.3125 pot, 
+Community outcomes (stdev = 0.196862 pcts , avgdev = 0.174265 pcts ), kurtosis = -0.590344
+0.169245 pct: least helpful community
+0.236586 pct: 9068 / 19600 (46.2653%)
+0.337397 pct: 2651 / 19600 (13.5255%)
+0.40512 pct (mean): mean- 0.597296   mean+ 0.402704 (skew 0.776058 tail right) 
+0.444483 pct: 1446 / 19600 (7.37755%)
+0.601874 pct: 3354 / 19600 (17.1122%)
+0.67161 pct: 2281 / 19600 (11.6378%)
+0.830648 pct: 354 / 19600 (1.80612%)
+0.926331 pct: 446 / 19600 (2.27551%)
+0.999893 pct: most helpful community
+CallStrength W(5m)=0.250518 L=0.699512 o.w_s=(0.250518,0.0499708)
+(MinRaise to $20.25) 	W(5x)=0.250518 L=0.699512 1o.w_s=(0.250518,0.0499708)
+ -  statrelation geom RAW - 
+8 dealt, 7 opp. (round), 5 opp. assumed str., 1 opp. still in
+Choice Optimal 10.125
+Choice Fold 10.125
+f(10.125)=0.994545
+CHECK/FOLD
+FoldGain()R=0.998972 x 0(=0 folds)	vs play:0.993516   ->assumes $10.125 forced
+ AgainstCall(10.125)=0.999879 from -$3.15133 @ 0.0573914
+AgainstRaise(10.125)=0.993636 from -$10.125 @ 0.942609
+        Push(10.125)=1 from $0 @ 0
+ AgainstCall(20.25)=0.999997 from -$7.8264 @ 0.000601409
+AgainstRaise(20.25)=0.986508 from -$20.25 @ 0.999399
+        Push(20.25)=1 from $0 @ 0
+OppRAISEChanceR [F] 0.942609 @ $20.25 ($10.125 now)	fold -- 0	W(5x)=0.250518 L=0.699512 1o.w_s=(0.250518,0.0499708)
+OppRAISEChanceR [F] 0.772416 @ $30.375 ($10.125 now)	fold -- 0.0512821	W(5x)=0.250518 L=0.699512 1o.w_s=(0.250518,0.0499708)
+OppRAISEChanceR [F] 0.450624 @ $50.625 ($0 now)	fold -- 0.0638095	W(5x)=0.250518 L=0.699512 1o.w_s=(0.250518,0.0499708)
+OppRAISEChanceR [F] 0.301465 @ $91.125 ($13.1155 now)	fold -- 0.145469	W(5.44444x)=0.244095 L=0.702933 1o.w_s=(0.244095,0.0529715)
+OppRAISEChanceR [F] 0.170371 @ $172.125 ($16.6425 now)	fold -- 0.216502	W(7.11111x)=0.235335 L=0.720126 1o.w_s=(0.235335,0.0445394)
+OppRAISEChanceR [F] 0.0905299 @ $334.125 ($21.5294 now)	fold -- 0.388676	W(9.61111x)=0.225141 L=0.739964 1o.w_s=(0.225141,0.0348948)
+OppRAISEChanceR [F] 0.0416433 @ $658.125 ($25.7061 now)	fold -- 0.483468	W(13.2222x)=0.210164 L=0.762837 1o.w_s=(0.210164,0.0269988)
+OppRAISEChanceR [F] 0.0121196 @ $1306.12 ($31.1186 now)	fold -- 0.609514	W(17.9444x)=0.192131 L=0.789744 1o.w_s=(0.192131,0.0181248)
+OppRAISEChanceR [F] 0 @ $1500 ($32.1966 now)	fold -- 0.443846	W(14.0556x)=0.206062 L=0.766944 1o.w_s=(0.206062,0.0269947)
+
+(Fixed at $10.125)	W(5x)=0.250518 L=0.699512 1o.w_s=(0.250518,0.0499708)
+Guaranteed > $5.0625 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+4h 5h Kd community
+*
+(M) 62.6699%
+(M.w) 61.1482%
+(M.s) 3.04338%
+(M.l) 35.8084%
+(Better All-in) 75.0231%
+(Re.s) 0.370028%
+(Better Mean Rank) 81.2925%
+(Ra.s) 0%
+
+*
+5c 7d Bet to call 0 (from 0) at 25.3125 pot, 
+Community outcomes (stdev = 0.0912999 pcts , avgdev = 0.0578413 pcts ), kurtosis = 3.78363
+0.510738 pct: least helpful community
+0.542957 pct: 10 / 47 (21.2766%)
+0.60766 pct: 27 / 47 (57.4468%)
+0.626699 pct (mean): mean- 0.723404   mean+ 0.276596 (skew 1.982 tail right) 
+0.635214 pct: 3 / 47 (6.38298%)
+0.7275 pct: 3 / 47 (6.38298%)
+0.784361 pct: 0 / 47 (0%)
+0.832279 pct: 2 / 47 (4.25532%)
+0.932883 pct: 2 / 47 (4.25532%)
+0.936375 pct: most helpful community
+CallStrength W(1m)=0.611482 L=0.358084 o.w_s=(0.611482,0.0304338)
+(MinRaise to $10.125) 	W(1x)=0.611482 L=0.358084 1o.w_s=(0.611482,0.0304338)
+ -  statrelation geom RAW - 
+8 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 0
+Choice Fold 9
+f(0)=1.00493
+CALL 0
+FoldGain()M=0.998965 x 0(=0 folds)	vs play:1.00389   ->assumes $10.125 forced
+ AgainstCall(0)=1.00389 from +$15.8633 @ 0.366943
+AgainstRaise(0)=1 from $0 @ 0.633057
+        Push(0)=1 from $0 @ 0
+ AgainstCall(10.125)=1.00306 from +$18.2724 @ 0.25085
+AgainstRaise(10.125)=0.994905 from -$10.125 @ 0.74915
+        Push(10.125)=1 from $0 @ 0
+OppRAISEChanceM [*] 0.474943 @ $10.125 ($10.125 now)	fold -- 0	W(1x)=0.611482 L=0.358084 1o.w_s=(0.611482,0.0304338)
+OppRAISEChanceM [*] 0.474101 @ $20.25 ($10.125 now)	fold -- 0.0811808	W(1x)=0.611482 L=0.358084 1o.w_s=(0.611482,0.0304338)
+OppRAISEChanceM [F] 0.633057 @ $40.5 ($11.6178 now)	fold -- 0.329757	W(5x)=0.174558 L=0.803426 1o.w_s=(0.174558,0.0220157)
+OppRAISEChanceM [F] 0.348787 @ $81 ($15.9289 now)	fold -- 0.529331	W(6.33333x)=0.171386 L=0.825909 1o.w_s=(0.171386,0.0027045)
+OppRAISEChanceM [F] 0.189557 @ $162 ($21.4175 now)	fold -- 0.688173	W(8.16667x)=0.159084 L=0.837429 1o.w_s=(0.159084,0.00348739)
+OppRAISEChanceM [F] 0.0933611 @ $324 ($28.9567 now)	fold -- 0.781018	W(10.6667x)=0.144703 L=0.850742 1o.w_s=(0.144703,0.00455495)
+OppRAISEChanceM [F] 0.0423882 @ $648 ($36.8615 now)	fold -- 0.812607	W(14.5x)=0.125177 L=0.868631 1o.w_s=(0.125177,0.00619189)
+OppRAISEChanceM [F] 0.0122403 @ $1296 ($47.5565 now)	fold -- 0.829252	W(20x)=0.101885 L=0.889575 1o.w_s=(0.101885,0.00854054)
+OppRAISEChanceM [F] 0 @ $1489.88 ($50.4768 now)	fold -- 0.810447	W(15.3333x)=0.121391 L=0.872061 1o.w_s=(0.121391,0.00654775)
+
+(Fixed at $0)	W(1x)=0.611482 L=0.358084 1o.w_s=(0.611482,0.0304338)
+Guaranteed > $25.3125 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+*
+5c 7d Bet to call 18 (from 0) at 43.3125 pot, 
+Community outcomes (stdev = 0.0912999 pcts , avgdev = 0.0578413 pcts ), kurtosis = 3.78363
+0.510738 pct: least helpful community
+0.542957 pct: 10 / 47 (21.2766%)
+0.60766 pct: 27 / 47 (57.4468%)
+0.626699 pct (mean): mean- 0.723404   mean+ 0.276596 (skew 1.982 tail right) 
+0.635214 pct: 3 / 47 (6.38298%)
+0.7275 pct: 3 / 47 (6.38298%)
+0.784361 pct: 0 / 47 (0%)
+0.832279 pct: 2 / 47 (4.25532%)
+0.932883 pct: 2 / 47 (4.25532%)
+0.936375 pct: most helpful community
+CallStrength W(1m)=0.611482 L=0.358084 o.w_s=(0.611482,0.0304338)
+(MinRaise to $36) 	W(1x)=0.611482 L=0.358084 1o.w_s=(0.611482,0.0304338)
+ -  statrelation geom RAW - 
+8 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 18
+Choice Fold 22.5
+f(18)=1.00735
+CALL 18
+FoldGain()M=0.998965 x 0(=0 folds)	vs play:1.00631   ->assumes $10.125 forced
+ AgainstCall(18)=1.00979 from +$20.4245 @ 0.715787
+AgainstRaise(18)=0.996551 from -$18 @ 0.284213
+        Push(18)=1 from $0 @ 0
+ AgainstCall(36)=1.00501 from +$24.2704 @ 0.309128
+AgainstRaise(36)=0.983243 from -$36 @ 0.690872
+        Push(36)=1 from $0 @ 0
+OppRAISEChanceM [*] 0 @ $36 ($18 now)	fold -- 0	W(1x)=0.611482 L=0.358084 1o.w_s=(0.611482,0.0304338)
+OppRAISEChanceM [*] 0 @ $54 ($18 now)	fold -- 0.0214738	W(1x)=0.611482 L=0.358084 1o.w_s=(0.611482,0.0304338)
+OppRAISEChanceM [*] 0 @ $90 ($20.7163 now)	fold -- 0.163592	W(1x)=0.611482 L=0.358084 1o.w_s=(0.611482,0.0304338)
+OppRAISEChanceM [F] 0.284213 @ $162 ($28.3181 now)	fold -- 0.413354	W(5.83333x)=0.174921 L=0.822588 1o.w_s=(0.174921,0.00249099)
+OppRAISEChanceM [F] 0.153088 @ $306 ($38.0756 now)	fold -- 0.64535	W(7.33333x)=0.164317 L=0.832552 1o.w_s=(0.164317,0.00313153)
+OppRAISEChanceM [F] 0.0745681 @ $594 ($50.0215 now)	fold -- 0.781376	W(9.66667x)=0.150456 L=0.845417 1o.w_s=(0.150456,0.00412793)
+OppRAISEChanceM [F] 0.0253799 @ $1170 ($65.5316 now)	fold -- 0.805845	W(13.1667x)=0.131442 L=0.862935 1o.w_s=(0.131442,0.00562252)
+OppRAISEChanceM [F] 0 @ $1489.88 ($71.2981 now)	fold -- 0.802551	W(10.6667x)=0.144703 L=0.850742 1o.w_s=(0.144703,0.00455495)
+
+(Fixed at $18)	W(1x)=0.611482 L=0.358084 1o.w_s=(0.611482,0.0304338)
+Guaranteed > $25.3125 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+4h 5h Kd Ah community
+*
+(M) 51.0738%
+(M.w) 49.2556%
+(M.s) 3.63636%
+(M.l) 47.108%
+(Better All-in) 60.2899%
+(Re.s) 1.54589%
+(Better Mean Rank) 59.0426%
+(Ra.s) 0%
+
+*
+5c 7d Bet to call 0 (from 0) at 61.3125 pot, 
+Community outcomes (stdev = 0.148102 pcts , avgdev = 0.101045 pcts ), kurtosis = 1.02188
+0.29596 pct: least helpful community
+0.306566 pct: 8 / 46 (17.3913%)
+0.449206 pct: 7 / 46 (15.2174%)
+0.503319 pct: 21 / 46 (45.6522%)
+0.510738 pct (mean): mean- 0.717391   mean+ 0.282609 (skew 0.942503 tail right) 
+0.556566 pct: 1 / 46 (2.17391%)
+0.654545 pct: 5 / 46 (10.8696%)
+0.773341 pct: 0 / 46 (0%)
+0.874495 pct: 4 / 46 (8.69565%)
+0.903535 pct: most helpful community
+CallStrength W(1m)=0.492556 L=0.47108 o.w_s=(0.492556,0.0363636)
+(MinRaise to $10.125) 	W(1x)=0.492556 L=0.47108 1o.w_s=(0.492556,0.0363636)
+ -  statrelation geom RAW - 
+8 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 0
+Choice Fold 40.5
+f(0)=1.02618
+CALL 0
+FoldGain()M=0.987771 x 0(=0 folds)	vs play:1.01395   ->assumes $10.125 forced
+ AgainstCall(0)=1.01167 from +$31.3146 @ 0.551156
+AgainstRaise(0)=1.00225 from +$7.39165 @ 0.448844
+        Push(0)=1 from $0 @ 0
+ AgainstCall(10.125)=1.00839 from +$30.9988 @ 0.400842
+AgainstRaise(10.125)=0.995873 from -$10.125 @ 0.599158
+        Push(10.125)=1 from $0 @ 0
+OppRAISEChanceM [*] 0.448844 @ $10.125 ($10.125 now)	fold -- 0	W(1x)=0.492556 L=0.47108 1o.w_s=(0.492556,0.0363636)
+OppRAISEChanceM [*] 0.448002 @ $20.25 ($0 now)	fold -- 0	W(1x)=0.492556 L=0.47108 1o.w_s=(0.492556,0.0363636)
+OppRAISEChanceM [*] 0.44277 @ $40.5 ($15.8107 now)	fold -- 0.0392775	W(1x)=0.492556 L=0.47108 1o.w_s=(0.492556,0.0363636)
+OppRAISEChanceM [*] 0.438953 @ $81 ($24.0141 now)	fold -- 0.287809	W(1x)=0.492556 L=0.47108 1o.w_s=(0.492556,0.0363636)
+OppRAISEChanceM [F] 0.33439 @ $162 ($35.7473 now)	fold -- 0.474098	W(6.16667x)=0.0337652 L=0.966235 1o.w_s=(0.0337652,0)
+OppRAISEChanceM [F] 0.191956 @ $324 ($52.4439 now)	fold -- 0.628692	W(7.83333x)=0.0183209 L=0.981679 1o.w_s=(0.0183209,0)
+OppRAISEChanceM [F] 0.0867905 @ $648 ($76.2405 now)	fold -- 0.698234	W(10.3333x)=0.00824184 L=0.991758 1o.w_s=(0.00824184,0)
+OppRAISEChanceM [F] 0.023145 @ $1296 ($110.832 now)	fold -- 0.769227	W(11.8333x)=0.00283999 L=0.99716 1o.w_s=(0.00283999,0)
+OppRAISEChanceM [F] 0 @ $1471.88 ($118.823 now)	fold -- 0.680255	W(10.6667x)=0.00704143 L=0.992959 1o.w_s=(0.00704143,0)
+
+(Fixed at $0)	W(1x)=0.492556 L=0.47108 1o.w_s=(0.492556,0.0363636)
+Guaranteed > $61.3125 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+*
+5c 7d Bet to call 805.5 (from 0) at 866.812 pot, 
+Community outcomes (stdev = 0.148102 pcts , avgdev = 0.101045 pcts ), kurtosis = 1.02188
+0.29596 pct: least helpful community
+0.306566 pct: 8 / 46 (17.3913%)
+0.449206 pct: 7 / 46 (15.2174%)
+0.503319 pct: 21 / 46 (45.6522%)
+0.510738 pct (mean): mean- 0.717391   mean+ 0.282609 (skew 0.942503 tail right) 
+0.556566 pct: 1 / 46 (2.17391%)
+0.654545 pct: 5 / 46 (10.8696%)
+0.773341 pct: 0 / 46 (0%)
+0.874495 pct: 4 / 46 (8.69565%)
+0.903535 pct: most helpful community
+CallStrength W(1m)=0.492556 L=0.47108 o.w_s=(0.492556,0.0363636)
+(MinRaise to $1611) 	W(1x)=0.492556 L=0.47108 1o.w_s=(0.492556,0.0363636)
+ -  statrelation geom RAW - 
+8 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 1471.88
+Choice Fold 1471.88
+f(805.5)=0.552341
+raiseGain: f(1471.88)=0.552341
+CHECK/FOLD
+FoldGain()M=1.31314 x 36.6667(=15.0177 folds)	vs play:0.865478   ->assumes $10.125 forced
+ AgainstCall(805.5)=1 from $0 @ 0
+AgainstRaise(805.5)=0.865478 from -$198 @ 1
+        Push(805.5)=1 from $0 @ 0
+ AgainstCall(1471.88)=0.865478 from -$198 @ 1
+AgainstRaise(1471.88)=1 from $0 @ 0
+        Push(1471.88)=1 from $0 @ 0
+OppRAISEChanceM [*] 0 @ $1471.88 ($666.375 now)	fold -- 0	W(1x)=0.492556 L=0.47108 1o.w_s=(0.492556,0.0363636)
+
+(Fixed at $805.5)	W(1x)=0.492556 L=0.47108 1o.w_s=(0.492556,0.0363636)
+Guaranteed > $61.3125 is in the pot for sure
+OppFoldChance% ...    0   d\0

--- a/holdem/unittests/playlogs.expected/6.txt
+++ b/holdem/unittests/playlogs.expected/6.txt
@@ -1,0 +1,146 @@
+
+==========#6==========
+Playing as ~
+*
+(M) 51.0192%
+(M.w) 48.9384%
+(M.s) 4.16167%
+(M.l) 46.8999%
+(Better All-in) 57.4286%
+(Re.s) 0.244898%
+(Better Mean Rank) 54.4898%
+(Ra.s) 0.244898%
+
+*
+3c Qc Bet to call 11.25 (from 11.25) at 28.125 pot, 
+Community outcomes (stdev = 0.171713 pcts , avgdev = 0.146549 pcts ), kurtosis = -0.42608
+0.221445 pct: least helpful community
+0.306756 pct: 2163 / 19600 (11.0357%)
+0.3863 pct: 7605 / 19600 (38.801%)
+0.49343 pct: 2172 / 19600 (11.0816%)
+0.510192 pct (mean): mean- 0.576122   mean+ 0.423878 (skew 0.754229 tail right) 
+0.59981 pct: 3962 / 19600 (20.2143%)
+0.741888 pct: 1869 / 19600 (9.53571%)
+0.815853 pct: 1203 / 19600 (6.13776%)
+0.930051 pct: 626 / 19600 (3.19388%)
+0.999938 pct: most helpful community
+CallStrength W(7m)=0.281335 L=0.683493 o.w_s=(0.281335,0.0351722)
+(MinRaise to $22.5) 	W(7x)=0.281335 L=0.683493 1o.w_s=(0.281335,0.0351722)
+ -  statrelation geom RAW - 
+8 dealt, 7 opp. (round), 7 opp. assumed str., 1 opp. still in
+Choice Optimal 11.25
+Choice Fold 11.25
+f(11.25)=0.997184
+CHECK/FOLD
+FoldGain()R=0.999435 x 0(=0 folds)	vs play:0.996619   ->assumes $11.25 forced
+ AgainstCall(11.25)=0.999888 from -$2.84284 @ 0.118936
+AgainstRaise(11.25)=0.99673 from -$11.25 @ 0.881064
+        Push(11.25)=1 from $0 @ 0
+ AgainstCall(22.5)=0.999996 from -$7.45181 @ 0.00147573
+AgainstRaise(22.5)=0.99259 from -$22.5 @ 0.998524
+        Push(22.5)=1 from $0 @ 0
+OppRAISEChanceR [F] 0.881064 @ $22.5 ($11.25 now)	fold -- 0	W(7x)=0.281335 L=0.683493 1o.w_s=(0.281335,0.0351722)
+OppRAISEChanceR [F] 0.774438 @ $33.75 ($11.25 now)	fold -- 0.0512821	W(7x)=0.281335 L=0.683493 1o.w_s=(0.281335,0.0351722)
+OppRAISEChanceR [F] 0.449616 @ $56.25 ($0 now)	fold -- 0.114456	W(7x)=0.281335 L=0.683493 1o.w_s=(0.281335,0.0351722)
+OppRAISEChanceR [F] 0.300595 @ $101.25 ($14.5728 now)	fold -- 0.259312	W(7x)=0.281335 L=0.683493 1o.w_s=(0.281335,0.0351722)
+OppRAISEChanceR [F] 0.172939 @ $191.25 ($18.4917 now)	fold -- 0.473341	W(7.125x)=0.280175 L=0.684146 1o.w_s=(0.280175,0.0356786)
+OppRAISEChanceR [F] 0.0935548 @ $371.25 ($23.9216 now)	fold -- 0.561861	W(9.45833x)=0.266236 L=0.699224 1o.w_s=(0.266236,0.0345402)
+OppRAISEChanceR [F] 0.0452115 @ $731.25 ($28.5623 now)	fold -- 0.644495	W(12.9583x)=0.253072 L=0.716663 1o.w_s=(0.253072,0.0302651)
+OppRAISEChanceR [F] 0.0176151 @ $1451.25 ($34.5762 now)	fold -- 0.669237	W(17.9167x)=0.240639 L=0.735013 1o.w_s=(0.240639,0.0243482)
+OppRAISEChanceR [F] 0.00677199 @ $2240 ($39.0196 now)	fold -- 0.663487	W(15.875x)=0.245531 L=0.728069 1o.w_s=(0.245531,0.0263997)
+
+(Fixed at $11.25)	W(7x)=0.281335 L=0.683493 1o.w_s=(0.281335,0.0351722)
+Guaranteed > $5.625 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+Jc Ks Ah community
+*
+(M) 53.0936%
+(M.w) 48.6948%
+(M.s) 8.7976%
+(M.l) 42.5076%
+(Better All-in) 54.0241%
+(Re.s) 0.185014%
+(Better Mean Rank) 62.9252%
+(Ra.s) 0%
+
+*
+3c Qc Bet to call 0 (from 0) at 28.125 pot, 
+Community outcomes (stdev = 0.125559 pcts , avgdev = 0.0865001 pcts ), kurtosis = 3.30048
+0.434497 pct: least helpful community
+0.446391 pct: 24 / 47 (51.0638%)
+0.530936 pct (mean): mean- 0.553191   mean+ 0.446809 (skew 1.96034 tail right) 
+0.549805 pct: 14 / 47 (29.7872%)
+0.591063 pct: 5 / 47 (10.6383%)
+0.671992 pct: 0 / 47 (0%)
+0.739847 pct: 0 / 47 (0%)
+0.807703 pct: 0 / 47 (0%)
+0.897011 pct: 4 / 47 (8.51064%)
+0.909486 pct: most helpful community
+CallStrength W(1m)=0.486948 L=0.425076 o.w_s=(0.486948,0.087976)
+(MinRaise to $11.25) 	W(1x)=0.486948 L=0.425076 1o.w_s=(0.486948,0.087976)
+ -  statrelation geom RAW - 
+8 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 0
+Choice Fold 5
+f(0)=1.00205
+CALL 0
+FoldGain()M=0.999433 x 0(=0 folds)	vs play:1.00149   ->assumes $11.25 forced
+ AgainstCall(0)=1.00149 from +$14.9326 @ 0.301006
+AgainstRaise(0)=1 from $0 @ 0.698994
+        Push(0)=1 from $0 @ 0
+ AgainstCall(11.25)=1.00089 from +$15.5327 @ 0.172827
+AgainstRaise(11.25)=0.996918 from -$11.25 @ 0.827173
+        Push(11.25)=1 from $0 @ 0
+OppRAISEChanceM [*] 0.473985 @ $11.25 ($11.25 now)	fold -- 0	W(1x)=0.486948 L=0.425076 1o.w_s=(0.486948,0.087976)
+OppRAISEChanceM [*] 0.472433 @ $22.5 ($11.25 now)	fold -- 0.0750001	W(1x)=0.486948 L=0.425076 1o.w_s=(0.486948,0.087976)
+OppRAISEChanceM [F] 0.698994 @ $45 ($12.9087 now)	fold -- 0.301975	W(5x)=0.151745 L=0.808508 1o.w_s=(0.151745,0.0397471)
+OppRAISEChanceM [F] 0.383586 @ $90 ($17.6988 now)	fold -- 0.522385	W(6.33333x)=0.138207 L=0.814679 1o.w_s=(0.138207,0.0471141)
+OppRAISEChanceM [F] 0.219437 @ $180 ($23.7972 now)	fold -- 0.652181	W(8.16667x)=0.121239 L=0.821395 1o.w_s=(0.121239,0.0573657)
+OppRAISEChanceM [F] 0.0964026 @ $360 ($32.1741 now)	fold -- 0.689803	W(10.6667x)=0.105313 L=0.823451 1o.w_s=(0.105313,0.0712359)
+OppRAISEChanceM [F] 0.0459871 @ $720 ($40.9572 now)	fold -- 0.71719	W(14.5x)=0.085917 L=0.820812 1o.w_s=(0.085917,0.0932708)
+OppRAISEChanceM [F] 0.0177862 @ $1440 ($52.8406 now)	fold -- 0.762074	W(20x)=0.0624954 L=0.812864 1o.w_s=(0.0624954,0.12464)
+OppRAISEChanceM [F] 0.00677199 @ $2228.75 ($61.4195 now)	fold -- 0.728879	W(17.5x)=0.0728305 L=0.81669 1o.w_s=(0.0728305,0.11048)
+
+(Fixed at $0)	W(1x)=0.486948 L=0.425076 1o.w_s=(0.486948,0.087976)
+Guaranteed > $28.125 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+*
+3c Qc Bet to call 80 (from 0) at 108.125 pot, 
+Community outcomes (stdev = 0.125559 pcts , avgdev = 0.0865001 pcts ), kurtosis = 3.30048
+0.434497 pct: least helpful community
+0.446391 pct: 24 / 47 (51.0638%)
+0.530936 pct (mean): mean- 0.553191   mean+ 0.446809 (skew 1.96034 tail right) 
+0.549805 pct: 14 / 47 (29.7872%)
+0.591063 pct: 5 / 47 (10.6383%)
+0.671992 pct: 0 / 47 (0%)
+0.739847 pct: 0 / 47 (0%)
+0.807703 pct: 0 / 47 (0%)
+0.897011 pct: 4 / 47 (8.51064%)
+0.909486 pct: most helpful community
+CallStrength W(1m)=0.486948 L=0.425076 o.w_s=(0.486948,0.087976)
+(MinRaise to $160) 	W(1x)=0.486948 L=0.425076 1o.w_s=(0.486948,0.087976)
+ -  statrelation geom RAW - 
+8 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 80
+Choice Fold 80
+f(80)=0.987026
+CHECK/FOLD
+FoldGain()M=1.00603 x 16.6667(=6.17914 folds)	vs play:0.993057   ->assumes $11.25 forced
+ AgainstCall(80)=1.00391 from +$19.8824 @ 0.594999
+AgainstRaise(80)=0.989188 from -$80 @ 0.405001
+        Push(80)=1 from $0 @ 0
+ AgainstCall(160)=1.00143 from +$20.2901 @ 0.213372
+AgainstRaise(160)=0.958092 from -$160 @ 0.786628
+        Push(160)=1 from $0 @ 0
+OppRAISEChanceM [*] 0 @ $160 ($80 now)	fold -- 0	W(1x)=0.486948 L=0.425076 1o.w_s=(0.486948,0.087976)
+OppRAISEChanceM [*] 0 @ $240 ($80 now)	fold -- 0.0555607	W(1x)=0.486948 L=0.425076 1o.w_s=(0.486948,0.087976)
+OppRAISEChanceM [F] 0.405001 @ $400 ($92.0726 now)	fold -- 0.260272	W(5.16667x)=0.150036 L=0.809296 1o.w_s=(0.150036,0.040668)
+OppRAISEChanceM [F] 0.197669 @ $720 ($126.258 now)	fold -- 0.512754	W(6.5x)=0.136528 L=0.815437 1o.w_s=(0.136528,0.0480349)
+OppRAISEChanceM [F] 0.0776309 @ $1360 ($169.225 now)	fold -- 0.653979	W(8.5x)=0.118932 L=0.821856 1o.w_s=(0.118932,0.0592124)
+OppRAISEChanceM [F] 0.00451977 @ $2228.75 ($207.748 now)	fold -- 0.650044	W(7.83333x)=0.123913 L=0.820583 1o.w_s=(0.123913,0.0555043)
+
+(Fixed at $80)	W(1x)=0.486948 L=0.425076 1o.w_s=(0.486948,0.087976)
+Guaranteed > $28.125 is in the pot for sure
+OppFoldChance% ...    0   d\0

--- a/holdem/unittests/playlogs.expected/9.txt
+++ b/holdem/unittests/playlogs.expected/9.txt
@@ -1,0 +1,197 @@
+
+==========#9==========
+Playing as ~
+*
+(M) 64.6024%
+(M.w) 63.4889%
+(M.s) 2.22694%
+(M.l) 34.2841%
+(Better All-in) 91.7959%
+(Re.s) 0.244898%
+(Better Mean Rank) 94.9796%
+(Ra.s) 0.244898%
+
+*
+Td Ad Bet to call 2.25 (from 0) at 3.375 pot, 
+Community outcomes (stdev = 0.14636 pcts , avgdev = 0.129032 pcts ), kurtosis = -1.02255
+0.340367 pct: least helpful community
+0.412595 pct: 546 / 19600 (2.78571%)
+0.498904 pct: 5052 / 19600 (25.7755%)
+0.571119 pct: 5187 / 19600 (26.4643%)
+0.646024 pct (mean): mean- 0.571071   mean+ 0.428929 (skew 0.445807 tail right) 
+0.681026 pct: 2345 / 19600 (11.9643%)
+0.764932 pct: 2631 / 19600 (13.4235%)
+0.851818 pct: 3027 / 19600 (15.4439%)
+0.943276 pct: 812 / 19600 (4.14286%)
+1 pct: most helpful community
+CallStrength W(2r)=0.899788 L=0.0955602 o.w_s=(0.948571,0.00244898)
+(MinRaise to $4.5) 	W(2x)=0.584864 L=0.394172 2o.w_s=(0.615642,0.0109363)
+ -  statranking algb RAW - 
+8 dealt, 7 opp. (round), 2 opp. assumed str., 2 opp. still in
+Choice Optimal 2.25
+Choice Fold 3
+f(2.25)=1.00071
+CALL 2.25
+FoldGain()R=0.999522 x 0(=0 folds)	vs play:1.00023
+ AgainstCall(2.25)=1.00201 from +$3.32088 @ 0.434094
+AgainstRaise(2.25)=0.998224 from -$2.25 @ 0.565906
+        Push(2.25)=1 from $0 @ 0
+ AgainstCall(4.5)=1.0012 from +$1.86736 @ 0.459677
+AgainstRaise(4.5)=0.996881 from -$4.5 @ 0.496946
+        Push(4.5)=1.00023 from +$3.76267 @ 0.0433774
+OppRAISEChanceR [*] 0.291366 @ $4.5 ($2.25 now)	fold -- 0.0433774	W(2x)=0.584864 L=0.394172 2o.w_s=(0.615642,0.0109363)
+OppRAISEChanceR [*] 0.291187 @ $6.75 ($2.25 now)	fold -- 0.121743	W(13.8679x)=0.34671 L=0.62639 2o.w_s=(0.537505,0.0204622)
+OppRAISEChanceR [F] 0.565906 @ $11.25 ($0 now)	fold -- 0.380091	W(16.3444x)=0.322409 L=0.64664 2o.w_s=(0.526688,0.0247009)
+OppRAISEChanceR [F] 0.398316 @ $20.25 ($2.91456 now)	fold -- 0.545304	W(20.8999x)=0.284129 L=0.6778 2o.w_s=(0.508078,0.0329694)
+OppRAISEChanceR [F] 0.24974 @ $38.25 ($3.69833 now)	fold -- 0.65121	W(27.1633x)=0.271822 L=0.680456 2o.w_s=(0.500147,0.0421297)
+OppRAISEChanceR [F] 0.141715 @ $74.25 ($4.78431 now)	fold -- 0.728156	W(36.4573x)=0.262341 L=0.686644 2o.w_s=(0.494699,0.0459641)
+OppRAISEChanceR [F] 0.0748289 @ $146.25 ($5.71246 now)	fold -- 0.787617	W(49.9179x)=0.25453 L=0.695282 2o.w_s=(0.490829,0.0462149)
+OppRAISEChanceR [F] 0.0372745 @ $290.25 ($6.91524 now)	fold -- 0.835636	W(69.5617x)=0.245738 L=0.70799 2o.w_s=(0.487007,0.0438758)
+OppRAISEChanceR [F] 0.0172469 @ $578.25 ($8.57921 now)	fold -- 0.881127	W(96.9589x)=0.237122 L=0.723958 2o.w_s=(0.483973,0.0382101)
+OppRAISEChanceR [F] 0 @ $717 ($8.83531 now)	fold -- 0.889373	W(107.863x)=0.233129 L=0.729247 2o.w_s=(0.48207,0.0374461)
+
+(Fixed at $2.25)	W(2x)=0.584864 L=0.394172 2o.w_s=(0.615642,0.0109363)
+Guaranteed > $0 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+*
+Td Ad Bet to call 5 (from 2.25) at 9.5 pot, 
+Community outcomes (stdev = 0.14636 pcts , avgdev = 0.129032 pcts ), kurtosis = -1.02255
+0.340367 pct: least helpful community
+0.412595 pct: 546 / 19600 (2.78571%)
+0.498904 pct: 5052 / 19600 (25.7755%)
+0.571119 pct: 5187 / 19600 (26.4643%)
+0.646024 pct (mean): mean- 0.571071   mean+ 0.428929 (skew 0.445807 tail right) 
+0.681026 pct: 2345 / 19600 (11.9643%)
+0.764932 pct: 2631 / 19600 (13.4235%)
+0.851818 pct: 3027 / 19600 (15.4439%)
+0.943276 pct: 812 / 19600 (4.14286%)
+1 pct: most helpful community
+CallStrength W(2m)=0.584864 L=0.394172 o.w_s=(0.584864,0.0209636)
+(MinRaise to $7.75) 	W(2x)=0.584864 L=0.394172 1o.w_s=(0.584864,0.0209636)
+ -  statranking algb RAW - 
+8 dealt, 7 opp. (round), 2 opp. assumed str., 1 opp. still in
+Choice Optimal 5
+Choice Fold 10
+f(5)=1.00415
+CALL 5
+FoldGain()R=0.996862 x 0(=0 folds)	vs play:1.00101
+ AgainstCall(5)=1.00251 from +$2.29299 @ 0.785153
+AgainstRaise(5)=0.998502 from -$5 @ 0.214847
+        Push(5)=1 from $0 @ 0
+ AgainstCall(7.75)=1.00205 from +$2.81739 @ 0.521491
+AgainstRaise(7.75)=0.996322 from -$5.51099 @ 0.478509
+        Push(7.75)=1 from $0 @ 0
+OppRAISEChanceR [*] 0 @ $7.75 ($2.75 now)	fold -- 0	W(2x)=0.584864 L=0.394172 1o.w_s=(0.584864,0.0209636)
+OppRAISEChanceR [*] 0 @ $12.75 ($2.75 now)	fold -- 0.0465465	W(2x)=0.584864 L=0.394172 1o.w_s=(0.584864,0.0209636)
+OppRAISEChanceR [*] 0 @ $20.5 ($3.09571 now)	fold -- 0.114154	W(2x)=0.584864 L=0.394172 1o.w_s=(0.584864,0.0209636)
+OppRAISEChanceR [*] 0 @ $36 ($3.96513 now)	fold -- 0.45399	W(5.88889x)=0.463859 L=0.483647 1o.w_s=(0.463859,0.0524939)
+OppRAISEChanceR [F] 0.214847 @ $67 ($5.09297 now)	fold -- 0.61786	W(7.88889x)=0.412257 L=0.51902 1o.w_s=(0.412257,0.0687231)
+OppRAISEChanceR [F] 0.121396 @ $129 ($6.24818 now)	fold -- 0.746702	W(10.5556x)=0.353328 L=0.56365 1o.w_s=(0.353328,0.0830226)
+OppRAISEChanceR [F] 0.0642443 @ $253 ($7.78246 now)	fold -- 0.79926	W(14.3333x)=0.341953 L=0.630403 1o.w_s=(0.341953,0.0276437)
+OppRAISEChanceR [F] 0.0317016 @ $501 ($9.2433 now)	fold -- 0.891359	W(19.6667x)=0.292063 L=0.671489 1o.w_s=(0.292063,0.0364472)
+OppRAISEChanceR [F] 0 @ $717 ($10.1989 now)	fold -- 0.914503	W(23.2222x)=0.279135 L=0.679495 1o.w_s=(0.279135,0.0413695)
+
+(Fixed at $5)	W(2x)=0.584864 L=0.394172 1o.w_s=(0.584864,0.0209636)
+Guaranteed > $2.25 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+2d Qd Kc community
+*
+(M) 74.2964%
+(M.w) 73.3938%
+(M.s) 1.80529%
+(M.l) 24.8009%
+(Better All-in) 91.9519%
+(Re.s) 0%
+(Better Mean Rank) 92.8571%
+(Ra.s) 0%
+
+*
+Td Ad Bet to call 12.5 (from 0) at 24.75 pot, 
+Community outcomes (stdev = 0.160198 pcts , avgdev = 0.146417 pcts ), kurtosis = -1.36086
+0.593863 pct: least helpful community
+0.609355 pct: 22 / 47 (46.8085%)
+0.671334 pct: 7 / 47 (14.8936%)
+0.736496 pct: 0 / 47 (0%)
+0.742964 pct (mean): mean- 0.617021   mean+ 0.382979 (skew 0.649812 tail right) 
+0.771981 pct: 3 / 47 (6.38298%)
+0.850603 pct: 0 / 47 (0%)
+0.894759 pct: 3 / 47 (6.38298%)
+0.984495 pct: 12 / 47 (25.5319%)
+0.993237 pct: most helpful community
+CallStrength W(1m)=0.733938 L=0.248009 o.w_s=(0.733938,0.0180529)
+(MinRaise to $25) 	W(1x)=0.733938 L=0.248009 1o.w_s=(0.733938,0.0180529)
+ -  statranking algb RAW - 
+8 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 12.5
+Choice Fold 711
+f(12.5)=1.02545
+CALL 12.5
+FoldGain()M=0.992978 x 0(=0 folds)	vs play:1.01843
+ AgainstCall(12.5)=1.01973 from +$15.1754 @ 0.925721
+AgainstRaise(12.5)=0.998696 from -$12.5 @ 0.0742785
+        Push(12.5)=1 from $0 @ 0
+ AgainstCall(25)=1.0162 from +$21.2495 @ 0.542661
+AgainstRaise(25)=0.990507 from -$14.7795 @ 0.457339
+        Push(25)=1 from $0 @ 0
+OppRAISEChanceM [*] 0 @ $25 ($12.5 now)	fold -- 0	W(1x)=0.733938 L=0.248009 1o.w_s=(0.733938,0.0180529)
+OppRAISEChanceM [*] 0 @ $37.5 ($12.5 now)	fold -- 0.067489	W(1x)=0.733938 L=0.248009 1o.w_s=(0.733938,0.0180529)
+OppRAISEChanceM [*] 0 @ $62.5 ($14.3863 now)	fold -- 0.272487	W(5x)=0.486346 L=0.504758 1o.w_s=(0.486346,0.00889562)
+OppRAISEChanceM [*] 0 @ $112.5 ($19.7278 now)	fold -- 0.426003	W(6.16667x)=0.473495 L=0.515534 1o.w_s=(0.473495,0.0109713)
+OppRAISEChanceM [*] 0 @ $212.5 ($26.4414 now)	fold -- 0.688804	W(8x)=0.459863 L=0.526345 1o.w_s=(0.459863,0.0137919)
+OppRAISEChanceM [F] 0.0742785 @ $412.5 ($34.7524 now)	fold -- 0.783891	W(10.6667x)=0.44256 L=0.53905 1o.w_s=(0.44256,0.0183893)
+OppRAISEChanceM [F] 0 @ $712 ($43.1763 now)	fold -- 0.854069	W(13.5x)=0.431801 L=0.555016 1o.w_s=(0.431801,0.0131822)
+
+(Fixed at $12.5)	W(1x)=0.733938 L=0.248009 1o.w_s=(0.733938,0.0180529)
+Guaranteed > $12.25 is in the pot for sure
+OppFoldChance% ...    0   d\0
+
+2s 2d Qd Kc community
+*
+(M) 65.2339%
+(M.w) 62.0026%
+(M.s) 6.46245%
+(M.l) 31.5349%
+(Better All-in) 62.7053%
+(Re.s) 0%
+(Better Mean Rank) 78.1915%
+(Ra.s) 0%
+
+*
+Td Ad Bet to call 49 (from 0) at 86.25 pot, 
+Community outcomes (stdev = 0.207281 pcts , avgdev = 0.18486 pcts ), kurtosis = -1.33512
+0.459091 pct: least helpful community
+0.469481 pct: 21 / 46 (45.6522%)
+0.602525 pct: 7 / 46 (15.2174%)
+0.631313 pct: 3 / 46 (6.52174%)
+0.652339 pct (mean): mean- 0.673913   mean+ 0.326087 (skew 0.613932 tail right) 
+0.715404 pct: 0 / 46 (0%)
+0.788636 pct: 0 / 46 (0%)
+0.840404 pct: 4 / 46 (8.69565%)
+0.970478 pct: 11 / 46 (23.913%)
+0.971717 pct: most helpful community
+CallStrength W(1m)=0.620026 L=0.315349 o.w_s=(0.620026,0.0646245)
+(MinRaise to $98) 	W(1x)=0.620026 L=0.315349 1o.w_s=(0.620026,0.0646245)
+ -  statranking algb RAW - 
+8 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 49
+Choice Fold 49
+f(49)=0.993131
+CHECK/FOLD
+FoldGain()M=1.02789 x 21.6667(=4.72518 folds)	vs play:1.02102
+ AgainstCall(49)=1.04049 from +$39.2288 @ 0.722059
+AgainstRaise(49)=0.98053 from -$49 @ 0.277941
+        Push(49)=1 from $0 @ 0
+ AgainstCall(98)=1.0266 from +$54.158 @ 0.343581
+AgainstRaise(98)=0.908036 from -$98 @ 0.656419
+        Push(98)=1 from $0 @ 0
+OppRAISEChanceM [*] 0 @ $98 ($49 now)	fold -- 0	W(1x)=0.620026 L=0.315349 1o.w_s=(0.620026,0.0646245)
+OppRAISEChanceM [*] 0 @ $147 ($0 now)	fold -- 0.131313	W(1x)=0.620026 L=0.315349 1o.w_s=(0.620026,0.0646245)
+OppRAISEChanceM [F] 0.277941 @ $245 ($76.5159 now)	fold -- 0.257194	W(5x)=0.243083 L=0.756917 1o.w_s=(0.243083,1.11022e-16)
+OppRAISEChanceM [F] 0.11961 @ $441 ($116.242 now)	fold -- 0.602189	W(6.33333x)=0.223057 L=0.776943 1o.w_s=(0.223057,0)
+OppRAISEChanceM [F] 0 @ $699.5 ($155.708 now)	fold -- 0.703103	W(7.66667x)=0.206397 L=0.793603 1o.w_s=(0.206397,1.11022e-16)
+
+(Fixed at $49)	W(1x)=0.620026 L=0.315349 1o.w_s=(0.620026,0.0646245)
+Guaranteed > $37.25 is in the pot for sure
+OppFoldChance% ...    0   d\0

--- a/holdem/unittests/test_harness.sh
+++ b/holdem/unittests/test_harness.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# Example usage:
+# cd unittests && sh test_harness.sh ../bin/unittest_clang
+
+set -u
+
+set -e
+
+set -x
+
+# Clean up any old files, if they exist
+mkdir -p playlogs.old
+echo 'CLEANUP start'
+ls -1 playlogs.expected/ | xargs -I @ sh -c "test '!' -f '@' || mv -v '@' 'playlogs.old/@'"
+# ^^^ there's no `set -o pipefail` (it's not portable anyway) so this succeeds even if there is nothing to move
+
+# Set up the playlogs comparison folder for actual output
+mkdir -p playlogs.actual
+find playlogs.actual/ -iname '*.txt' -exec rm -v '{}' '+'
+
+# Run the command given!
+# e.g. if you invoked `sh test_harness.sh echo hello world` the line below will print "hello world" to the console
+"$@"
+
+# Grab the "actual" playlogs file corresponding to each "expected" playlogs file
+cd playlogs.expected/
+# ls -1 playlogs.expected/ | xargs -I @ mv -v @ playlogs.actual/@
+find . -iname '*.txt' -exec mv -v ../'{}' ../playlogs.actual/ ';'
+# ^^^ The `ls -1 … | xargs` version is simpler, but we need this script to be strict, even without `set -o pipefail` so this is the best we can come up with.
+cd ..
+
+# COMPARE!
+if test -z "$(ls -A playlogs.expected/)"; then
+  find playlogs.expected
+  echo 'Where are the reference logs?' 1>&2
+  pwd -P
+  ls -la
+  find playlogs.actual
+  exit 66 # 65 would be EX_DATAERR, 78 would be EX_CONFIG. We went with 66 EX_NOINPUT
+elif diff -urw playlogs.expected/ playlogs.actual/; then
+  echo 'PLAYLOGS MATCH ✅'
+else
+  DIFF_CMD_EXIT_CODE=$?
+  echo 'System test failed during: ' "$*" 1>&2
+  exit $DIFF_CMD_EXIT_CODE
+fi


### PR DESCRIPTION
I went back to 5472ced7f4afe3636338e5d9a9c5a97c7c53be8d since that's the first commit that ran https://github.com/yuzisee/pokeroo/actions/runs/17524010983 successfully on master.

For now we'll simply run the playlogs and verify that all the calculations are the same.

Results so far:
1. Original **based on https://github.com/yuzisee/pokeroo/commit/5472ced7f4afe3636338e5d9a9c5a97c7c53be8d Sept 7** https://github.com/yuzisee/pokeroo/actions/runs/17889488620/job/50868001925 is already failing against itself on some of the fold calculations?
   - BASELINE
1. Just after merging #31 https://github.com/yuzisee/pokeroo/actions/runs/17889626212 results TBD
   - Verified manually. Same as BASELINE.
   - → [**playlogs.r31.zip**](https://github.com/user-attachments/files/22457595/playlogs.r31.zip)
1. Just after merging #45 with this patch https://github.com/yuzisee/pokeroo/commit/330df63559930c91ccc01d1fe0f6ad9ae6fa9079 generates https://github.com/yuzisee/pokeroo/actions/runs/17905059943
   - → [playlogs_r45.zip](https://github.com/user-attachments/files/22457827/playlogs_r45.zip)
   - Same as BASELINE. Same as r31
1. In the middle of #49 testing https://github.com/yuzisee/pokeroo/actions/runs/17905246630 on https://github.com/yuzisee/pokeroo/commit/8cccecd902b908712324db7a3d842c7a711522c7
   - → [playlogs_duringr49.zip](https://github.com/user-attachments/files/22457898/playlogs_duringr49.zip)
   - Same as BASELINE. Same as r45 & r31
1. With #50 completed (before merging into master) https://github.com/yuzisee/pokeroo/actions/runs/17905370370
   - → [playlogs_atr50.zip](https://github.com/user-attachments/files/22457952/playlogs_atr50.zip)
   - Same as BASELINE. Same as r50 & r45 & r31

---

### Actual Bugfix

1. Just after merging #52 https://github.com/yuzisee/pokeroo/actions/runs/17905581940
   - → [playlogs_r52.zip](https://github.com/user-attachments/files/22458071/playlogs_r52.zip)
   - DIFFERENT from r50
1. Just after merging #56 https://github.com/yuzisee/pokeroo/actions/runs/17905465669
   - → [playlogs_r56.zip](https://github.com/user-attachments/files/22457996/playlogs_r56.zip)
   - SAME as r52
1. Just after merging #59 https://github.com/yuzisee/pokeroo/actions/runs/17889681612 results TBD
   - → [**playlogs.r59.zip**](https://github.com/user-attachments/files/22457588/playlogs.r59.zip)
   - SAME as r56; SAME as r52
1. Just after merging #60 https://github.com/yuzisee/pokeroo/actions/runs/17905866429
   - → [playlogs_r60.zip](https://github.com/user-attachments/files/22458272/playlogs_r60.zip)
   - SAME AS r59/r56/r52
1. Just after merging #55 https://github.com/yuzisee/pokeroo/actions/runs/17905931307
   - → [playlogs_r55.zip](https://github.com/user-attachments/files/22458301/playlogs_r55.zip)
   - SAME AS r60/r59/r56/r52
1. Just after merging #63 https://github.com/yuzisee/pokeroo/actions/runs/17906008889
   - → [playlogs_r63.zip](https://github.com/user-attachments/files/22458385/playlogs_r63.zip)
   - SAME AS r55 (and others in that collection)

---

### Probable root cause
https://github.com/yuzisee/pokeroo/pull/62#discussion_r2366829724

1. With #62 completed (before merging into master) https://github.com/yuzisee/pokeroo/pull/62/commits/b452d5d721ddf4fba497f348e901f93ee13ff30d
   - → [playlogs_atr62.zip](https://github.com/user-attachments/files/22458181/playlogs_atr62.zip)
   - → https://github.com/yuzisee/pokeroo/pull/62/commits/ba06d64942d39cc4d9dcc127935b6e98aa4f29c7 [playlogs_mid-r62_ba06d64942d39cc4d9dcc127935b6e98aa4f29c7.zip](https://github.com/user-attachments/files/22458457/playlogs_mid-r62_ba06d64942d39cc4d9dcc127935b6e98aa4f29c7.zip)
   - DIFFERENT from (r60, r63) r59
   - SAME AS master
1. Current master Sept 20 as of https://github.com/yuzisee/pokeroo/commit/35e57e4be6625c9aa75cd447b23349e1473f0453 → https://github.com/yuzisee/pokeroo/actions/runs/17889486165/job/50867998408 has a bunch of differences in fold calculations
   - [playlogs.unittests_clang-GitHub Actions 1000002501-runnervmf4ws1_2ab9ceab6067087dca8e827d9fec74a51e6cd27d.dev-playlog-githubactions_unittests.zip](https://github.com/user-attachments/files/22457443/playlogs.unittests_clang-GitHub.Actions.1000002501-runnervmf4ws1_2ab9ceab6067087dca8e827d9fec74a51e6cd27d.dev-playlog-githubactions_unittests.zip)
