### PR TITLE
Use a configurable `traceEnable` instead of bTraceEnable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Must compile successfully
       timeout-minutes: 1
       run: cd holdem && make SHELL="$SHELL -x"
-    - name: "…but `-D DEBUG_TRACE_SEARCH`, `-D DEBUG_TRACE_ZERO`, '-D DEBUG_TRACE_DEXF' and `-D NO_LOG_FILES` should also build without issues"
+    - name: "…but `-D DEBUG_TRACE_SEARCH`, `-D DEBUG_TRACE_ZERO`, '-D DEBUG_TRACE_DEXF', '-D DEBUG_TRACE_PWIN' and `-D NO_LOG_FILES` should also build without issues"
       timeout-minutes: 3
       run: |
         mkdir -v holdem/clang_plist
@@ -51,7 +51,7 @@ jobs:
         set -e
         # It seems that `clang++ --analyze` creates a lot of `*.plist` files?
         clang++ -Wl,-z,defs -o /dev/null -Werror -D NO_LOG_FILES -I../src ../src/*.cpp ../appsrc/*.cpp
-        clang++ --analyze -Werror -D DEBUG_TRACE_ZERO -D DEBUG_TRACE_SEARCH -D DEBUG_TRACE_DEXF ../src/*.cpp ../libsrc/interfaceC.cpp 2> static_analysis_errors.txt || cat static_analysis_errors.txt
+        clang++ --analyze -Werror -D DEBUG_TRACE_ZERO -D DEBUG_TRACE_SEARCH -D DEBUG_TRACE_DEXF -D DEBUG_TRACE_PWIN ../src/*.cpp ../libsrc/interfaceC.cpp 2> static_analysis_errors.txt || cat static_analysis_errors.txt
         # EX_DATAERR
         if test -s static_analysis_errors.txt; then
           echo "clang++ --analyze ← generated warnings even though they that don't fall under -Werror"

--- a/holdem/src/BluffGainInc.cpp
+++ b/holdem/src/BluffGainInc.cpp
@@ -49,7 +49,7 @@ float64 fd_yr;
         y = yr; dy = fd_yr;
 
 #ifdef DEBUG_TRACE_SEARCH
-        if(bTraceEnable) std::cout << "\t\t\tbNoRange" << std::flush;
+        if(traceEnable != nullptr) std::cout << "\t\t\tbNoRange" << std::flush;
 #endif
 
     }else
@@ -71,7 +71,7 @@ float64 fd_yr;
             y = yr; dy = fd_yr;
 
 #ifdef DEBUG_TRACE_SEARCH
-            if(bTraceEnable) std::cout << "\t\t\tbMax" << std::flush;
+            if(traceEnable != nullptr) std::cout << "\t\t\tbMax" << std::flush;
 #endif
         }
         else if( slider <= 0 )
@@ -82,7 +82,7 @@ float64 fd_yr;
             y = yl; dy = fd_yl;
 
 #ifdef DEBUG_TRACE_SEARCH
-            if(bTraceEnable) std::cout << "\t\t\tbMin" << std::flush;
+            if(traceEnable != nullptr) std::cout << "\t\t\tbMin" << std::flush;
 #endif
         }
         else
@@ -117,8 +117,8 @@ float64 fd_yr;
                     dy = fd_yl*(1-slider) - yl*autoSlope   +   fd_yr*slider + yr*autoSlope;
 
 #ifdef DEBUG_TRACE_SEARCH
-                    if(bTraceEnable) std::cout << "\t\t\t y(" << x << ") = " << yl << " * " << (1-slider) << " + " <<  yr << " * " << slider << std::endl;
-                    if(bTraceEnable) std::cout << "\t\t\t dy = " << fd_yl << " * " << (1-slider) << " - " <<  yl << " * " << autoSlope << " + " <<  fd_yr << " * " << slider << " + " <<  yr << " * " << autoSlope << std::endl;
+                    if(traceEnable != nullptr) std::cout << "\t\t\t y(" << x << ") = " << yl << " * " << (1-slider) << " + " <<  yr << " * " << slider << std::endl;
+                    if(traceEnable != nullptr) std::cout << "\t\t\t dy = " << fd_yl << " * " << (1-slider) << " - " <<  yl << " * " << autoSlope << " + " <<  fd_yr << " * " << slider << " + " <<  yr << " * " << autoSlope << std::endl;
 #endif // DEBUG_TRACE_SEARCH
 #ifdef TRANSFORMED_AUTOSCALES
                 }
@@ -546,7 +546,7 @@ void StateModel::query( const float64 betSize )
 #endif // DEBUGASSERT
 
 #ifdef DEBUG_TRACE_SEARCH
-        if(bTraceEnable)
+        if(traceEnable != nullptr)
         {
             std::cout << "\t\t(oppRaiseChance[" << i << "] , cur, highest) = " << oppRaisedChance_A[i].v  << " , "  << newRaisedChance << " , " << lastuptoRaisedChance << std::endl;
         }
@@ -644,7 +644,7 @@ void StateModel::query( const float64 betSize )
      struct AggregatedState gainCombined = table_spec.stateCombiner.combinedContributionOf(outcomePush, outcomeCalled, blendedRaises);
 
 #ifdef DEBUG_TRACE_SEARCH
-    if(bTraceEnable)
+    if(traceEnable != nullptr)
     {
       // https://github.com/yuzisee/pokeroo/commit/ecec2a0e4f8d119a01f310fef9ce4e4652c3ce58
         std::cout << "\t\t (gainWithFold*gainNormal*gainRaised) = " << gainCombined.contribution.v << std::endl;

--- a/holdem/src/callPrediction.h
+++ b/holdem/src/callPrediction.h
@@ -22,11 +22,12 @@
 #define HOLDEM_CallPredict
 
 
-
+// #define DEBUG_TRACE_PWIN
+// #define DEBUG_TRACE_DEXF
+// ^^^ Enable if you need to trace through a specific search (usually you'll set `bTraceEnable = true` near where the issue occurs)
+// ^^^ Disable (e.g. You can explicitly `#undef DEBUG_TRACE_PWIN`) if you don't want `.github/workflows/ci.yml` to test with it
 
 //#define DEBUG_CALLPRED_FUNCTION
-#undef DEBUG_TRACE_PWIN
-#undef DEBUG_TRACE_DEXF
 
 #include "math_support.h"
 #include "inferentials.h"
@@ -119,9 +120,9 @@ class ExactCallD : public IExf
     CommunityStatsCdf * ed() const {
         return &(fCore.callcumu);
     }
-#ifdef DEBUG_TRACE_EXACTCALL
-		std::ostream * traceOut;
-#endif
+    #ifdef DEBUG_TRACE_DEXF
+                   std::ostream * traceOut;
+    #endif
 
         ExactCallD(ExpectedCallD * const tbase //, CallCumulationD* data
                    ,
@@ -135,9 +136,10 @@ class ExactCallD : public IExf
         ,
         //ed(data)
         fCore(core)
-#ifdef DEBUG_TRACE_EXACTCALL
-					,traceOut(0)
-#endif
+        #ifdef DEBUG_TRACE_DEXF
+                                               ,traceOut(0)
+        #endif
+
             {
                 queryinput = UNINITIALIZED_QUERY;
                 querycallSteps = OPPONENTS_ARE_ALWAYS_ENCOURAGED_TO_RAISE;
@@ -194,20 +196,23 @@ class ExactCallBluffD
         float64 allFoldChanceD;
 
         float64 queryinputbluff;
-
         void query(const float64 betSize);
 
     public:
+#ifdef DEBUG_TRACE_EXACTCALL
+		std::ostream * traceOut;
+#endif
+
         float64 insuranceDeterrent;
 
-        ExactCallBluffD( ExpectedCallD * const tbase, struct CoreProbabilities &core
-
-                        //, CallCumulationD* data, CallCumulationD* foldData*
-                        )
+        ExactCallBluffD( ExpectedCallD * const tbase, struct CoreProbabilities &core )
     :
     tableinfo(tbase)
     ,
     fFoldCumu(core.foldcumu), fCallCumu(core.callcumu)
+    #ifdef DEBUG_TRACE_EXACTCALL
+					,traceOut(0)
+    #endif
     ,
     insuranceDeterrent(0)
                             {

--- a/holdem/src/callPredictionFunctions.cpp
+++ b/holdem/src/callPredictionFunctions.cpp
@@ -486,18 +486,18 @@ template<typename T1, typename T2> float64 FoldWaitLengthModel<T1, T2>::FindBest
     // i.e if we aren't cutting the search space in half anymore with each iteration, move on to FindMax below
 
 #ifdef DEBUG_TRACE_SEARCH
-    if (bTraceEnable) {
+    if(traceEnable != nullptr) {
       std::cerr << "ScalarFunctionModel::FindMax(" << (1/rarity()) <<  "," << ceil(maxTurns[0] + 1) << ") is next" << std::endl;
     }
 #endif
     bSearching = true;
     const float64 bestN = FindMax(1/rarity(), ceil(maxTurns[0] + 1) );
     #ifdef DEBUG_TRACE_SEARCH
-        if (bTraceEnable) { std::cerr << "bestN = " << bestN << std::endl; }
+        if(traceEnable != nullptr) { std::cerr << "bestN = " << bestN << std::endl; }
     #endif
     bSearching = false;
 #ifdef DEBUG_TRACE_SEARCH
-    if (bTraceEnable) {
+    if(traceEnable != nullptr) {
       std::cerr << "FoldWaitLengthModel::FindBestLength ALL CLEAR" << std::endl;
     }
 #endif
@@ -721,20 +721,20 @@ template<typename T> void FacedOddsAlgb<T>::query( const float64 w )
     const float64 U = (pot + betSize)*fw;
 
     #ifdef DEBUG_TRACE_SEARCH
-        if(bTraceEnable)
+        if(traceEnable != nullptr)
         {
-             std::cout << "\t\t\t faceOddsAlgb.FG.waitLength.SEARCH!" << std::endl;
+             *traceEnable << "\t\t\t faceOddsAlgb.FG.waitLength.SEARCH!" << std::endl;
              //FG.waitLength.bTraceEnable = true;
-             FG.bTraceEnable = true;
+             FG.traceEnable = this->traceEnable;
         }
     #endif
 
     lastF = U - betSize - FG.f(betSize);
 
     #ifdef DEBUG_TRACE_SEARCH
-        if(bTraceEnable)
+        if(traceEnable != nullptr)
         {
-             std::cout << "\t\t\t faceOddsAlgb(U,betSize,FG.f,FG.n) = (" << U << " , " << betSize << " , " << FG.f(betSize) << " , " << FG.n << ")" << std::endl;
+             *traceEnable << "\t\t\t faceOddsAlgb(U,betSize,FG.f,FG.n) = (" << U << " , " << betSize << " , " << FG.f(betSize) << " , " << FG.n << ")" << std::endl;
         }
     #endif
 

--- a/holdem/src/debug_flags.h
+++ b/holdem/src/debug_flags.h
@@ -72,7 +72,7 @@
 #define SEATS_AT_TABLE 10
 
 /* functionbase.h Debugging */
-#undef DEBUG_TRACE_ZERO
+// #define DEBUG_TRACE_ZERO
 // #define DEBUG_TRACE_SEARCH
 // ^^^ Enable if you need to trace through a specific search (usually you'll set `bTraceEnable = true` near where the issue occurs)
-// ^^^ Disable (i.e. You can explicitly `#undef DEBUG_TRACE_SEARCH`) if you don't want `.github/workflows/ci.yml` to test with it
+// ^^^ Disable (e.g. You can explicitly `#undef DEBUG_TRACE_SEARCH`) if you don't want `.github/workflows/ci.yml` to test with it

--- a/holdem/src/functionbase.cpp
+++ b/holdem/src/functionbase.cpp
@@ -117,17 +117,17 @@ float64 ScalarFunctionModel::searchStep(float64 x1, float64 y1, float64 x2, floa
 float64 ScalarFunctionModel::FindMax(float64 x1, float64 x2)
 {
         #ifdef DEBUG_TRACE_SEARCH
-            if(bTraceEnable) std::cout << "\t\t\t(x1,y1)=" << x1 << std::flush;
+            if(traceEnable != nullptr) std::cout << "\t\t\t(x1,y1)=" << x1 << std::flush;
         #endif
     const float64 y1 = f(x1);
         #ifdef DEBUG_TRACE_SEARCH
-            if(bTraceEnable)
+            if(traceEnable != nullptr)
             {  std::cout <<","<< y1 << endl;
                std::cout << "\t\t\t(x2,y2)=" << x2 << std::flush; }
         #endif
     const float64 y2 = f(x2);
         #ifdef DEBUG_TRACE_SEARCH
-            if(bTraceEnable) std::cout <<","<< y2 << endl;
+            if(traceEnable != nullptr) std::cout <<","<< y2 << endl;
         #endif
 
     const float64 xb = bisectionStep(x1,x2);
@@ -135,7 +135,7 @@ float64 ScalarFunctionModel::FindMax(float64 x1, float64 x2)
 
 
         #ifdef DEBUG_TRACE_SEARCH
-			if(bTraceEnable)
+			if(traceEnable != nullptr)
 			{
 				std::streamsize olprec = std::cout.precision();
 				std::cout.precision(16);
@@ -170,7 +170,7 @@ float64 ScalarFunctionModel::FindMax(float64 x1, float64 x2)
 			        	y2b = f(x2b);
 
 					      #ifdef DEBUG_TRACE_SEARCH
-                  if(bTraceEnable) {
+                  if(traceEnable != nullptr) {
                     std::cout << "\t\t\tMore than one maximum?" << endl;
                     std::cout << "\t\t\t\tx<" << x1 << ",\t" << x1b << ",\t" << x1b_outer << ",\t" << x2b << ",\t" << x2b_outer << ",\t" << x2b << ",\t" << x2 << ">" << endl;
                     std::cout << "\t\t\t\ty<" << y1 << ",\t" << y1b << ",\t __ ,\t" << y2b << ",\t __ ,\t" << y2b << ",\t" << y2 << ">" << endl;
@@ -183,7 +183,7 @@ float64 ScalarFunctionModel::FindMax(float64 x1, float64 x2)
 	                float64 rightmax = std::round(FindMax(x2b_outer,x2)/quantum)*quantum;
 
          					#ifdef DEBUG_TRACE_SEARCH
-                      if(bTraceEnable) std::cout << "\t\t  <leftmax , rightmax> = < " << leftmax << " , " << rightmax << " >" << endl;
+                      if(traceEnable != nullptr) std::cout << "\t\t  <leftmax , rightmax> = < " << leftmax << " , " << rightmax << " >" << endl;
                   #endif
 
                     // Clean up rounding error before querying.
@@ -195,7 +195,7 @@ float64 ScalarFunctionModel::FindMax(float64 x1, float64 x2)
                     }
 
                					#ifdef DEBUG_TRACE_SEARCH
-                            if(bTraceEnable) std::cout << "\t\t  CONCLUSION = Max{ " << f(leftmax) << " , " << f(rightmax) << " }" << endl;
+                            if(traceEnable != nullptr) std::cout << "\t\t  CONCLUSION = Max{ " << f(leftmax) << " , " << f(rightmax) << " }" << endl;
                         #endif
 
                     // Now compare the recursive results to each other...
@@ -209,17 +209,17 @@ float64 ScalarFunctionModel::FindMax(float64 x1, float64 x2)
 	    }
 
         #ifdef DEBUG_TRACE_SEARCH
-            if(bTraceEnable) std::cout << "\t\t  Reduced to (xb,yb)=" << xb <<","<< yb << endl;
+            if(traceEnable != nullptr) std::cout << "\t\t  Reduced to (xb,yb)=" << xb <<","<< yb << endl;
         #endif
 
         return std::round(xb/quantum)*quantum;
     }
         #ifdef DEBUG_TRACE_SEARCH
-            if(bTraceEnable) std::cout << "\t\t  FindTurningPoint" << endl;
+            if(traceEnable != nullptr) std::cout << "\t\t  FindTurningPoint" << endl;
         #endif
   float64 local_max = FindTurningPoint(x1, y1, xb, yb, x2, y2, 1);
   #ifdef DEBUG_TRACE_SEARCH
-      if(bTraceEnable) std::cout << "\t\t\tFindMax returns " << local_max << endl;
+      if(traceEnable != nullptr) std::cout << "\t\t\tFindMax returns " << local_max << endl;
   #endif
   return local_max;
 }
@@ -228,17 +228,17 @@ float64 ScalarFunctionModel::FindMin(float64 x1, float64 x2)
 {
 
   #ifdef DEBUG_TRACE_SEARCH
-      if(bTraceEnable) std::cout << "\t\t\t(x1,y1)=" << x1 << std::flush;
+      if(traceEnable != nullptr) std::cout << "\t\t\t(x1,y1)=" << x1 << std::flush;
   #endif
 const float64 y1 = f(x1);
   #ifdef DEBUG_TRACE_SEARCH
-      if(bTraceEnable)
+      if(traceEnable != nullptr)
       {  std::cout <<","<< y1 << endl;
          std::cout << "\t\t\t(x2,y2)=" << x2 << std::flush; }
   #endif
 const float64 y2 = f(x2);
   #ifdef DEBUG_TRACE_SEARCH
-      if(bTraceEnable) std::cout <<","<< y2 << endl;
+      if(traceEnable != nullptr) std::cout <<","<< y2 << endl;
   #endif
 
     const float64 xb = bisectionStep(x1,x2);
@@ -289,7 +289,7 @@ const float64 y2 = f(x2);
 float64 ScalarFunctionModel::SplitTurningPoint(float64 x1, float64 xa, float64 xb, float64 x2, float64 signDir)
 {
         #ifdef DEBUG_TRACE_SEARCH
-            if(bTraceEnable) std::cout << "\t\tSplit <" << x1 << "," << xa << "," << xb << "," << x2 << ">" << std::endl;
+            if(traceEnable != nullptr) std::cout << "\t\tSplit <" << x1 << "," << xa << "," << xb << "," << x2 << ">" << std::endl;
         #endif
 
     if( x2 - x1 < quantum/2 )
@@ -418,7 +418,7 @@ float64 ScalarFunctionModel::FindTurningPoint(float64 x1, float64 y1, float64 xb
 
 
         #ifdef DEBUG_TRACE_SEARCH
-            if(bTraceEnable) std::cout << "\t\t\tNewton <newtonxb, dy1,dy2> <" << newtonxb << ", " << dy1 << "," << dy2 << ">" << std::endl;
+            if(traceEnable != nullptr) std::cout << "\t\t\tNewton <newtonxb, dy1,dy2> <" << newtonxb << ", " << dy1 << "," << dy2 << ">" << std::endl;
         #endif
 
         if( stepMode > 0 && newtonxb < x2 - quantum/2 && newtonxb > x1 + quantum/2 )
@@ -433,7 +433,7 @@ float64 ScalarFunctionModel::FindTurningPoint(float64 x1, float64 y1, float64 xb
 
 
         #ifdef DEBUG_TRACE_SEARCH
-            if(bTraceEnable) std::cout << "\t\t\tSlide  x<" << x1 << ", " << xb << ", " << x2 << ">   y<" << y1 << ", " << yb << ", " << y2 << ">" << std::endl;
+            if(traceEnable != nullptr) std::cout << "\t\t\tSlide  x<" << x1 << ", " << xb << ", " << x2 << ">   y<" << y1 << ", " << yb << ", " << y2 << ">" << std::endl;
         #endif
 	  } // end while IsDifferentSign && x2-x1 quantum/2
     }
@@ -448,13 +448,13 @@ float64 ScalarFunctionModel::FindTurningPoint(float64 x1, float64 y1, float64 xb
 */
 
 #ifdef DEBUG_TRACE_SEARCH
-    if(bTraceEnable) std::cout << "\t\t\tINVARIANT: Either all of y1, yb, y2 are monotonic " << (y1-yb) << " ≷ " << (y2-yb) << "   OR   x2 ↔ x1 are so close together we can return early " << (quantum/2) << endl;
+    if(traceEnable != nullptr) std::cout << "\t\t\tINVARIANT: Either all of y1, yb, y2 are monotonic " << (y1-yb) << " ≷ " << (y2-yb) << "   OR   x2 ↔ x1 are so close together we can return early " << (quantum/2) << endl;
 #endif
 
     while(x2 - x1 > quantum/2)
     {
         #ifdef DEBUG_TRACE_SEARCH
-            if(bTraceEnable) std::cout << "\t\t\tGo x<" << x1 << "," << x2 << ">  y<" << y1 << "," << y2 << ">" << std::endl;
+            if(traceEnable != nullptr) std::cout << "\t\t\tGo x<" << x1 << "," << x2 << ">  y<" << y1 << "," << y2 << ">" << std::endl;
         #endif
 
         ++stepMode;
@@ -634,11 +634,11 @@ float64 ScalarFunctionModel::FindTurningPoint(float64 x1, float64 y1, float64 xb
         //xn = searchStep(x1,y1,xb,yb,x2,y2);
     } // end while(x2 - x1 > quantum/2)
     #ifdef DEBUG_TRACE_SEARCH
-        if(bTraceEnable) std::cout << "\t\t\tRESULT: bisectionStep(" << x1 << " , " << x2 << ")" << endl;
+        if(traceEnable != nullptr) std::cout << "\t\t\tRESULT: bisectionStep(" << x1 << " , " << x2 << ")" << endl;
     #endif
     float64 local_optimum = std::round(bisectionStep(x1,x2)/quantum)*quantum;
     #ifdef DEBUG_TRACE_SEARCH
-        if(bTraceEnable) std::cout << "\t\t\tlocal_optimum = " << local_optimum << endl;
+        if(traceEnable != nullptr) std::cout << "\t\t\tlocal_optimum = " << local_optimum << endl;
     #endif
     return local_optimum;
 }
@@ -699,10 +699,10 @@ float64 ScalarFunctionModel::FindZero(float64 x1, float64 x2, bool bRoundToQuant
     yb = f(xb);
 
         #ifdef DEBUG_TRACE_ZERO
-            if(bTraceEnable)
+            if(traceEnable != nullptr)
             {
-                std::cout << "FindZero (x1,xb,x2) = (" << x1 <<","<< xb <<","<< x2 << ")" << endl;
-                std::cout << "FindZero (y1,yb,y2) = (" << y1 <<","<< yb <<","<< y2 << ")" << endl;
+                *traceEnable << "FindZero (x1,xb,x2) = (" << x1 <<","<< xb <<","<< x2 << ")" << endl;
+                *traceEnable << "FindZero (y1,yb,y2) = (" << y1 <<","<< yb <<","<< y2 << ")" << endl;
             }
         #endif
 
@@ -718,7 +718,7 @@ float64 ScalarFunctionModel::FindZero(float64 x1, float64 x2, bool bRoundToQuant
 
 
 			#ifdef DEBUG_TRACE_ZERO
-				if(bTraceEnable) std::cout << "\t\tPossible xn " << xn << std::endl;
+				if(traceEnable != nullptr) *traceEnable << "\t\tPossible xn " << xn << std::endl;
 			#endif
 
 			bool bNewtonValid = xn < x2 - quantum/2 && xn > x1 + quantum/2;
@@ -743,7 +743,7 @@ float64 ScalarFunctionModel::FindZero(float64 x1, float64 x2, bool bRoundToQuant
 					}
 
 					#ifdef DEBUG_TRACE_ZERO
-						if(bTraceEnable) std::cout << "\t\t\t Shortcut! Switch to xn and xb: new (x1,x2) = (" << x1 << "," << x2 << ")" << std::endl;
+						if(traceEnable != nullptr) *traceEnable << "\t\t\t Shortcut! Switch to xn and xb: new (x1,x2) = (" << x1 << "," << x2 << ")" << std::endl;
 					#endif
 
 					xb = regularfalsiStep(x1,y1,x2,y2);
@@ -754,14 +754,14 @@ float64 ScalarFunctionModel::FindZero(float64 x1, float64 x2, bool bRoundToQuant
 					yb = yn;
 
 					#ifdef DEBUG_TRACE_ZERO
-						if(bTraceEnable) std::cout << "\t\t\t No shortcut" << std::endl;
+						if(traceEnable != nullptr) *traceEnable << "\t\t\t No shortcut" << std::endl;
 					#endif
 				}
 			}///Otherwise we stay with xb and yb which is false position or bisection
 		}///Newton couldn't have been valid.
 
         #ifdef DEBUG_TRACE_ZERO
-            if(bTraceEnable) std::cout << "\t\tSelected <xb,yb> = <" << xb << "," << yb << ">" << std::endl;
+            if(traceEnable != nullptr) *traceEnable << "\t\tSelected <xb,yb> = <" << xb << "," << yb << ">" << std::endl;
         #endif
 
         if( fabs(yb) < DBL_EPSILON ) {
@@ -792,16 +792,15 @@ float64 ScalarFunctionModel::FindZero(float64 x1, float64 x2, bool bRoundToQuant
         yb = f(xb);
 
         #ifdef DEBUG_TRACE_ZERO
-            if(bTraceEnable)
-            {
-                std::cout << "\tNext (x1,xb,x2) = (" << x1 <<","<< xb <<","<< x2 << ")" << endl;
-                std::cout << "\tNext (y1,yb,y2) = (" << y1 <<","<< yb <<","<< y2 << ")" << endl;
-            }
+          if(traceEnable != nullptr) {
+             *traceEnable << "\tNext (x1,xb,x2) = (" << x1 <<","<< xb <<","<< x2 << ")" << endl;
+             *traceEnable << "\tNext (y1,yb,y2) = (" << y1 <<","<< yb <<","<< y2 << ")" << endl;
+           }
         #endif
     }
 
     #ifdef DEBUG_TRACE_ZERO
-        if(bTraceEnable) std::cout << "Done. f(" << std::round(xb/quantum)*quantum << ") is zero" << endl;
+        if(traceEnable != nullptr) *traceEnable << "Done. f(" << std::round(xb/quantum)*quantum << ") is zero" << endl;
     #endif
 
     if (bRoundToQuantum) {

--- a/holdem/src/functionbase.h
+++ b/holdem/src/functionbase.h
@@ -75,12 +75,12 @@ class ScalarFunctionModel : public IFunctionDifferentiable
     float64 getQuantum() const override final { return quantum; }
 
     #if defined(DEBUG_TRACE_SEARCH) || defined(DEBUG_TRACE_ZERO)
-    bool bTraceEnable;
+    std::ostream * traceEnable;
     #endif
 
     ScalarFunctionModel(float64 step) : quantum(step)
     #if defined(DEBUG_TRACE_SEARCH) || defined(DEBUG_TRACE_ZERO)
-    ,bTraceEnable(false)
+    ,traceEnable(nullptr)
     #endif
     {};
 	virtual float64 FindMax(float64,float64) ;

--- a/holdem/src/functionmodel.cpp
+++ b/holdem/src/functionmodel.cpp
@@ -734,7 +734,7 @@ float64 GainModelGeom::gd(const float64 betSize, const float64 y)
     if( betSize > estat->callBet()+adjQuantum && betSize < estat->minRaiseTo()-adjQuantum )
     {
 #ifdef DEBUG_TRACE_SEARCH
-        if(bTraceEnable) std::cout << "\t\t\tWithin minraise, reevaluate... @ " << estat->callBet() << " and " << estat->minRaiseTo() << " instead of " << betSize << std::endl;
+        if(traceEnable != nullptr) std::cout << "\t\t\tWithin minraise, reevaluate... @ " << estat->callBet() << " and " << estat->minRaiseTo() << " instead of " << betSize << std::endl;
 #endif
 
 
@@ -761,7 +761,7 @@ float64 GainModelGeom::gd(const float64 betSize, const float64 y)
     if( exf < minexf - fracQuantum )
     {
 #ifdef DEBUG_TRACE_SEARCH
-        if(bTraceEnable) std::cout << "\t\t\tvery low exf for now: " << exf << " < " << minexf << std::endl;
+        if(traceEnable != nullptr) std::cout << "\t\t\tvery low exf for now: " << exf << " < " << minexf << std::endl;
 #endif
 
         dexf = 0.0;
@@ -782,13 +782,13 @@ float64 GainModelGeom::gd(const float64 betSize, const float64 y)
 
 
 #ifdef DEBUG_TRACE_SEARCH
-    if(bTraceEnable && betSize < estat->callBet()) std::cout << "\t\t\tbetSize would be a fold!" << betSize << std::endl;
+    if((traceEnable != nullptr) && betSize < estat->callBet()) std::cout << "\t\t\tbetSize would be a fold!" << betSize << std::endl;
 #endif
 
     if( betSize < estat->callBet() ) return 1; ///"Negative raise" means betting less than the minimum call = FOLD
 
     #ifdef DEBUG_TRACE_SEARCH
-        if(bTraceEnable) std::cout << "\t\t\t\tGainModelGeom::gd → hdx(…,dexf = " << dexf << std::endl;
+        if(traceEnable != nullptr) std::cout << "\t\t\t\tGainModelGeom::gd → hdx(…,dexf = " << dexf << std::endl;
     #endif
     return hdx(x, betSize, exf, dexf, f_pot, dx, fOutcome, y) * estat->betFraction(1.0);
 
@@ -886,7 +886,7 @@ float64 GainModelGeom::fd(const float64 betSize, const float64 y)
     const float64 betVal = gd(betSize, y);
 
 #ifdef DEBUG_TRACE_SEARCH
-    if(bTraceEnable) std::cout << "\t\tfd figures " << betVal << std::endl;
+    if(traceEnable != nullptr) std::cout << "\t\tfd figures " << betVal << std::endl;
 #endif
 
     return betVal;
@@ -932,7 +932,7 @@ float64 GainModelNoRisk::g(float64 betSize)
     if( betSize < estat->callBet() && betSize < estat->maxBet() ) return 0.0; ///"Negative raise" means betting less than the minimum call = FOLD
 
     #ifdef DEBUG_TRACE_SEARCH
-        if(bTraceEnable)
+        if(traceEnable != nullptr)
         {
           const StatResult & inShape = fOutcome.ViewShape(betSize);
             std::cout << "\t\t\t(t_w,t_s,t_l) " << inShape.wins << "," << inShape.splits << "," << inShape.loss << std::endl;
@@ -1059,7 +1059,7 @@ float64 GainModelNoRisk::gd(float64 betSize, const float64 y)
     if( betSize > estat->callBet()+adjQuantum && betSize < estat->minRaiseTo() - adjQuantum )
     {
 #ifdef DEBUG_TRACE_SEARCH
-        if(bTraceEnable) std::cout << "\t\t\tWithin minraise, reevaluate... @ " << estat->callBet() << " and " << estat->minRaiseTo() << " instead of " << betSize << std::endl;
+        if(traceEnable != nullptr) std::cout << "\t\t\tWithin minraise, reevaluate... @ " << estat->callBet() << " and " << estat->minRaiseTo() << " instead of " << betSize << std::endl;
 #endif
 
         const float64 splitDist = gd(estat->callBet(),y)*(estat->minRaiseTo()-betSize)+gd(estat->minRaiseTo(),y)*(estat->callBet()-betSize);
@@ -1083,13 +1083,13 @@ float64 GainModelNoRisk::gd(float64 betSize, const float64 y)
 
 
 #ifdef DEBUG_TRACE_SEARCH
-    if(bTraceEnable && betSize < estat->callBet()) std::cout << "\t\t\tbetSize would be a fold!" << betSize << std::endl;
+    if((traceEnable != nullptr) && betSize < estat->callBet()) std::cout << "\t\t\tbetSize would be a fold!" << betSize << std::endl;
 #endif
     if( betSize < estat->callBet() ) return 1; ///"Negative raise" means betting less than the minimum call = FOLD
 
     //     dh/dx * dx/dbetSize
     #ifdef DEBUG_TRACE_SEARCH
-        if(bTraceEnable) std::cout << "\t\t\t\tGainModelNoRisk::gd → hdx(…,dexf = " << dexf << std::endl;
+        if(traceEnable != nullptr) std::cout << "\t\t\t\tGainModelNoRisk::gd → hdx(…,dexf = " << dexf << std::endl;
     #endif
     return hdx(x, betSize, exf, dexf, fOutcome, y) * estat->betFraction(1.0);
 

--- a/holdem/src/stratPosition.cpp
+++ b/holdem/src/stratPosition.cpp
@@ -508,6 +508,9 @@ void PositionalStrategy::printBetGradient(std::ofstream &logF, ExactCallD & opp_
 #ifdef LOGPOSITION
 
 
+#ifdef DEBUG_TRACE_PWIN
+    opp_fold.traceOut = &logF;
+#endif
 
 
     int32 raiseStep = 0;
@@ -561,6 +564,10 @@ void PositionalStrategy::printBetGradient(std::ofstream &logF, ExactCallD & opp_
     logF << "(Fixed at $" << separatorBet << ")";
     printPessimisticWinPct(logF, separatorBet, csrp);
     logF << endl;
+
+#ifdef DEBUG_TRACE_PWIN
+    opp_fold.traceOut = nullptr;
+#endif
 
     const float64 minNextRaiseTo = (separatorBet*2-betToCall);
     if( maxShowdown - minNextRaiseTo < DBL_EPSILON ) return;


### PR DESCRIPTION
The hope is to greatly reduce the diff size of https://github.com/yuzisee/pokeroo/pull/75 and https://github.com/yuzisee/pokeroo/pull/71 because even https://github.com/yuzisee/pokeroo/pull/77 is failing to compile right now and it's getting annoying