### PR TITLE
The caching properties of meanConv are suspicious.

### DIFF
--- a/holdem/src/callPrediction.cpp
+++ b/holdem/src/callPrediction.cpp
@@ -229,7 +229,7 @@ template<typename T> float64 ExactCallD::facedOdds_raise_Geom_forTest(float64 st
     // We don't need to set w, because a.FindZero searches over w
     a.FG.waitLength.load(cps, avgBlind);
     a.FG.waitLength.opponents = opponents;
-    a.FG.waitLength.meanConv = foldwait_length_distr;
+    a.FG.waitLength.setMeanConv(foldwait_length_distr);
 
     //a.FG.dw_dbet = 0; //We don't need this, unless we want the derivative of FG.f; Since we don't need any extrema or zeros of FG, we can set this to anything
 
@@ -286,7 +286,7 @@ template<typename T> float64 ExactCallD::dfacedOdds_raise_dfacedBet_GeomDEXF(con
         FoldGainModel<T, OppositionPerspective> myFG(tableinfo->chipDenom());
 
     //USE myFG for F_a and F_b
-        myFG.waitLength.meanConv = foldwait_length_distr;
+        myFG.waitLength.setMeanConv(foldwait_length_distr);
         myFG.waitLength.setW(w);
         myFG.waitLength.load(cps, avgBlind);
         myFG.waitLength.opponents = opponents;
@@ -355,7 +355,7 @@ template<typename T> float64 ExactCallD::facedOdds_call_Geom(const ChipPositionS
     const float64 avgBlind = tableinfo->table->GetBlindValues().OpportunityPerHand(N);
     a.FG.waitLength.load(cps, avgBlind);
     a.FG.waitLength.opponents = opponents;
-    a.FG.waitLength.meanConv = foldwait_length_distr;
+    a.FG.waitLength.setMeanConv(foldwait_length_distr);
     //a.FG.dw_dbet = 0; //We don't need this, unless we want the derivative of FG.f; Since we don't need any extrema or zeros of FG, we can set this to anything
 
     return a.FindZero(0,1, false);
@@ -375,7 +375,7 @@ template<typename T> float64 ExactCallD::dfacedOdds_call_dbetSize_Geom(const Chi
     FG.waitLength.setW(w);
     FG.waitLength.load(cps, avgBlind);
     FG.waitLength.opponents = opponents;
-    FG.waitLength.meanConv = foldwait_length_distr;
+    FG.waitLength.setMeanConv(foldwait_length_distr);
     //FG.dw_dbet = 0; //Again, we don't need this
 
     const float64 wN_1 = std::pow(w,opponents-1);
@@ -407,7 +407,7 @@ template<typename T> float64 ExactCallBluffD::facedOdds_Algb(const ChipPositionS
     const float64 avgBlind = tableinfo->table->GetBlindValues().OpportunityPerHand(N);
     a.FG.waitLength.load(cps, avgBlind);
     a.FG.waitLength.opponents = opponents;
-    a.FG.waitLength.meanConv = foldwait_length_distr;
+    a.FG.waitLength.setMeanConv(foldwait_length_distr);
     //a.FG.dw_dbet = 0; //We don't need this...
 
     #if defined(DEBUG_TRACE_PWIN) && defined(DEBUG_TRACE_SEARCH)
@@ -1414,7 +1414,7 @@ float64 ExactCallBluffD::RiskPrice(const ExpectedCallD &tableinfo, FoldStatsCdf 
     FG.waitLength.bankroll = maxStack;
     FG.waitLength.opponents = 1;
     FG.waitLength.prevPot = tableinfo.table->GetPrevPotSize();
-    FG.waitLength.meanConv = foldcumu_caching;
+    FG.waitLength.setMeanConv(foldcumu_caching);
     const float64 riskprice = FG.FindZero(tableinfo.table->GetMinRaise() + tableinfo.callBet(),maxStack/2, true);
 
 
@@ -1542,10 +1542,11 @@ void OpponentHandOpportunity::query(const float64 betSize) {
                 // I guess technically this is mean but they know what you have, so pessimistically we're talking about them trying to beat only you.
                 // The problem is, we usually talk about being pessimistic to prevent overbets when _you_ have a good hand.
                 // In that case, e_opp would be counter-productive. Let's consider callcumu or even rank here instead.
-                FG.waitLength.meanConv =
-                //(opponentsFacingThem > 1.0) ?
-                nullptr
-                //: &(fCore.callcumu)
+                FG.waitLength.setMeanConv(
+                  //(opponentsFacingThem > 1.0) ?
+                  nullptr
+                  //: &(fCore.callcumu)
+                )
                 ;
                 // ( 1 / (x+1) )  ^ (1/x)
                 FG.waitLength.bankroll = fTable.ViewPlayer(pIndex)->GetMoney();

--- a/holdem/src/callPredictionFunctions.h
+++ b/holdem/src/callPredictionFunctions.h
@@ -144,8 +144,8 @@ class FoldWaitLengthModel : public virtual ScalarFunctionModel
 
     // Describe the hand they would be folding
     float64 w;                    // Set to RANK if meanConv is null. Set to MEAN_winpct if using *meanConv
-public:
     CallCumulationD<T1, T2> (* meanConv); // Set to null if using RANK for payout simulation
+public:
 
     // Describe the situation
     float64 amountSacrificeVoluntary; // you're giving up this much money each time you reach this situation (and fold) again
@@ -220,6 +220,7 @@ public:
         amountSacrificeVoluntary = (amount < 0) ? 0.0 : amount;
     }
 
+    void setMeanConv(CallCumulationD<T1, T2> * new_meanConv);
     void setW(float64 neww);
     float64 getW() const;
 

--- a/holdem/src/callSituation.cpp
+++ b/holdem/src/callSituation.cpp
@@ -70,7 +70,7 @@ float64 FoldOrCall::foldGain(MeanOrRank meanOrRank, const float64 extra, const f
     switch (meanOrRank) {
         case MEAN:
             // Since ExactCallD::ed() returns fCore.callcumu
-            FG.waitLength.meanConv = &(fCore.callcumu); //  &(fCore.____); // Which *e is this usually called with?
+            FG.waitLength.setMeanConv(  &(fCore.callcumu)  ); //  &(fCore.____); // Which *e is this usually called with?
             // One vote for: ea.ed from BluffGainInc's oppRaisedMyFoldGain
             // One vote for: ea.ed from BluffGainInc's "y -= myFoldGain"
 
@@ -78,7 +78,7 @@ float64 FoldOrCall::foldGain(MeanOrRank meanOrRank, const float64 extra, const f
             // One vote for: core.statmean.pct from statProbability constructor of ExpectedCallD
             break;
         case RANK:
-            FG.waitLength.meanConv = EMPTY_DISTRIBUTION;
+            FG.waitLength.setMeanConv( EMPTY_DISTRIBUTION );
             FG.waitLength.setW( fCore.statRanking().pct ); //fCore.callcumu.Pr_haveWinPCT_orbetter(fCore.statmean.pct); // rankW; // When called with e is 0, what is the rank -- how do we get that from fCore?
             // One vote for: const float64 rarity3 = core.callcumu.Pr_haveWinPCT_orbetter(core.statmean.pct); from StatResultProbabilities::Process_FoldCallMean
 
@@ -259,7 +259,7 @@ template<typename T> float64 ExpectedCallD::RiskLoss(const struct HypotheticalBe
     const float64 avgBlind = table->GetBlindValues().OpportunityPerHand(N);
 
     FoldGainModel<T, OppositionPerspective> FG(table->GetChipDenom()/2);
-    FG.waitLength.meanConv = foldwait_length_distr;
+    FG.waitLength.setMeanConv( foldwait_length_distr );
 
     if(foldwait_length_distr == 0)
     {

--- a/holdem/unittests/main.cpp
+++ b/holdem/unittests/main.cpp
@@ -458,7 +458,7 @@ namespace UnitTests {
         FoldWaitLengthModel<void, OppositionPerspective> fw;
         // From the opponent's point of view if he knows he's against a flush
         fw.setW( 0.0 ); // Their current hand does not pair the board so loses to an ace-high flush (but note there is a ~30% chance that they hit a pair other than a deuce and a ~4% chance of having one deuce)
-        fw.meanConv = &(statprob.core.foldcumu);
+        fw.setMeanConv( &(statprob.core.foldcumu) );
         fw.amountSacrificeForced = avgBlind;
         fw.bankroll = 1000.0;
         fw.setAmountSacrificeVoluntary(myConstributionToPastPot + myBetThisRound - avgBlind);
@@ -495,7 +495,7 @@ namespace UnitTests {
         FoldWaitLengthModel<void, void> fw;
 
         fw.setW( 0.75 ); // You have a decent hand, but it could be better and the re-raise was ridiculously enormous.
-        fw.meanConv = nullptr;
+        fw.setMeanConv( nullptr );
         fw.amountSacrificeForced = avgBlind;
         fw.bankroll = 1000.0;
         fw.setAmountSacrificeVoluntary(myConstributionToPastPot + myBetThisRound - avgBlind);
@@ -561,7 +561,7 @@ namespace UnitTests {
         FoldWaitLengthModel<void, void> fw;
 
         fw.setW(0.75); // You have a decent hand, but it could be better and the raise was large.
-        fw.meanConv = nullptr;
+        fw.setMeanConv( nullptr );
         fw.amountSacrificeForced = avgBlind;
         fw.bankroll = 10000.0;
         fw.setAmountSacrificeVoluntary(myConstributionToPastPot + myBetThisRound - avgBlind);
@@ -4291,11 +4291,11 @@ namespace RegressionTests {
         const float64 opponentsFacingThem = 1.0;
 
         FoldWaitLengthModel<void, void> waitLength;
-        waitLength.meanConv =
-        //(opponentsFacingThem > 1.0) ?
-        nullptr
-        //: &(fCore.callcumu)
-        ;
+        waitLength.setMeanConv(
+          //(opponentsFacingThem > 1.0) ?
+          nullptr
+          //: &(fCore.callcumu)
+        );
         // ( 1 / (x+1) )  ^ (1/x)
         const Player * const normalBot = myTable.ViewPlayer(5);
         waitLength.bankroll = normalBot->GetMoney();


### PR DESCRIPTION
 Do we ever change `meanConv` between calls to `rarity()`?