### PR TITLE
Baseline debugging for DEBUG_TRACE_DEXF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         set -e
         # It seems that `clang++ --analyze` creates a lot of `*.plist` files?
         clang++ -Wl,-z,defs -o /dev/null -Werror -D NO_LOG_FILES -I../src ../src/*.cpp ../appsrc/*.cpp
-        clang++ --analyze -Werror -D DEBUG_TRACE_ZERO -D DEBUG_TRACE_SEARCH -D DEBUG_TRACE_DEXF -D DEBUG_TRACE_PWIN ../src/*.cpp ../libsrc/interfaceC.cpp 2> static_analysis_errors.txt || cat static_analysis_errors.txt
+        clang++ --analyze -Werror -D DEBUG_TRACE_ZERO -D DEBUG_TRACE_SEARCH -D DEBUG_TRACE_DEXF=999 -D DEBUG_TRACE_PWIN ../src/*.cpp ../libsrc/interfaceC.cpp 2> static_analysis_errors.txt || cat static_analysis_errors.txt
         # EX_DATAERR
         if test -s static_analysis_errors.txt; then
           echo "clang++ --analyze ← generated warnings even though they that don't fall under -Werror"

--- a/holdem/src/callPrediction.cpp
+++ b/holdem/src/callPrediction.cpp
@@ -802,7 +802,7 @@ void ExactCallD::accumulateOneOpponentPossibleRaises(const int8 pIndex, ValueAnd
 				//To understand the above, consider that totalexf includes already made bets
 
           #ifdef DEBUG_TRACE_DEXF
-          if( traceOut_dexf != 0 )  *traceOut_dexf << " to bet " << oppBetMake << "more";
+          if( traceOut_dexf != 0 )  *traceOut_dexf << " to bet $" << oppBetMake << " more";
           #endif
 
           if( oppBetMake <= std::numeric_limits<float64>::epsilon() )

--- a/holdem/src/callPrediction.cpp
+++ b/holdem/src/callPrediction.cpp
@@ -498,7 +498,7 @@ void ExactCallD::query(const float64 betSize, const int32 callSteps)
     this->totaldexf = mydexf;
 
     #ifdef DEBUG_TRACE_DEXF
-            if( traceOut != 0 ) *traceOut << "Begin Query with mydexf " << mydexf << endl;
+            if( traceOut_dexf != 0 ) *traceOut_dexf << "\tBegin Query(betSize=" << betSize << ",callSteps=" << callSteps << ") with myexf=" << myexf << "  mydexf=" << mydexf << " ⇒ initialize to " << this->totalexf << " +" << this->totaldexf << "∂betSize" << endl;
     #endif
 
     this->noRaiseArraySize = 0;
@@ -535,13 +535,15 @@ void ExactCallD::query(const float64 betSize, const int32 callSteps)
     while( pIndex != tableinfo->playerID )
     {
       #ifdef DEBUG_TRACE_DEXF
-		  if( traceOut != 0 )
+		  if( traceOut_dexf != 0 )
 		  {
-		  	*traceOut << endl << "totaldexf is " << totaldexf << " overdexf is " << overdexf << endl;
-		  	*traceOut << "\tPlayer " << (int)pIndex;
+		  	*traceOut_dexf << endl << "\t\ttotalexf/totaldexf is " << this->totalexf << " +Δ" << this->totaldexf << " overexf/overdexf is " << overexf << " +∆" << overdexf << endl;
+		  	*traceOut_dexf << "\t\t↓ Player " << (int)pIndex;
 		  }
 		  #endif
 
+				// [!NOTE]
+				// This writes to `this->totalexf` and `this->totaldexf`
         this->accumulateOneOpponentPossibleRaises(pIndex, nextNoRaise_A, noRaiseArraySize_now, betSize, callSteps, &overexf, &overdexf);
 
         tableinfo->table->incrIndex(pIndex);
@@ -551,14 +553,14 @@ void ExactCallD::query(const float64 betSize, const int32 callSteps)
     delete [] nextNoRaise_A;
 
     #ifdef DEBUG_TRACE_DEXF
-    if( traceOut != 0 )  *traceOut << endl << "Final is " << totaldexf;
+    if( traceOut_dexf != 0 )  *traceOut_dexf << endl << "Final is " << this->totalexf << " +∂" << this->totaldexf;
     #endif
 
-    this->totalexf = totalexf - myexf - overexf;
-    this->totaldexf = totaldexf - mydexf - overdexf;
+    this->totalexf = this->totalexf - myexf - overexf;
+    this->totaldexf = this->totaldexf - mydexf - overdexf;
 
     #ifdef DEBUG_TRACE_DEXF
-    if( traceOut != 0 )  *traceOut << " adjusted to " << totaldexf << " by mydexf=" << mydexf << " and overdexf=" << overdexf << endl;
+    if( traceOut_dexf != 0 )  *traceOut_dexf << " adjusted to " << this->totalexf << "/" << this->totaldexf << " by myᵈexf=" << myexf << "∕" << mydexf << " and overᵈexf=" << overexf << "∕" << overdexf << endl;
     #endif
 
     if( totalexf < 0 ) this->totalexf = 0; //Due to rounding error in overexf?
@@ -800,7 +802,7 @@ void ExactCallD::accumulateOneOpponentPossibleRaises(const int8 pIndex, ValueAnd
 				//To understand the above, consider that totalexf includes already made bets
 
           #ifdef DEBUG_TRACE_DEXF
-          if( traceOut != 0 )  *traceOut << " to bet " << oppBetMake << "more";
+          if( traceOut_dexf != 0 )  *traceOut_dexf << " to bet " << oppBetMake << "more";
           #endif
 
           if( oppBetMake <= std::numeric_limits<float64>::epsilon() )
@@ -809,7 +811,7 @@ void ExactCallD::accumulateOneOpponentPossibleRaises(const int8 pIndex, ValueAnd
               nextdexf = 1;
 
               #ifdef DEBUG_TRACE_DEXF
-              if( traceOut != 0 )  *traceOut << " ALREADY CALLED" << endl ;
+              if( traceOut_dexf != 0 )  *traceOut_dexf << " ALREADY CALLED" << endl ;
               #endif
           }else
           {
@@ -832,7 +834,7 @@ void ExactCallD::accumulateOneOpponentPossibleRaises(const int8 pIndex, ValueAnd
               }
 
               #ifdef DEBUG_TRACE_DEXF
-              //if( traceOut != 0 )  *traceOut << " nextdexf=" << nextdexf << endl;
+              //if( traceOut_dexf != 0 )  *traceOut_dexf << " nextdexf=" << nextdexf << endl;
               #endif
 
           }
@@ -858,7 +860,7 @@ void ExactCallD::accumulateOneOpponentPossibleRaises(const int8 pIndex, ValueAnd
           nextdexf = 0;
 
               #ifdef DEBUG_TRACE_DEXF
-              if( traceOut != 0 )  *traceOut << " Is ALL IN" << endl;
+              if( traceOut_dexf != 0 )  *traceOut_dexf << " Is ALL IN" << endl;
               #endif
 
 				//Obviously the opponent won't raise...  ie. NoRaise = 100%
@@ -874,7 +876,7 @@ void ExactCallD::accumulateOneOpponentPossibleRaises(const int8 pIndex, ValueAnd
       this->totalexf += nextexf;
 
               #ifdef DEBUG_TRACE_DEXF
-              //if( traceOut != 0 )  *traceOut << "totaldexf was " << totaldexf;
+              //if( traceOut_dexf != 0 )  *traceOut_dexf << "totaldexf was " << totaldexf;
               #endif
 
       //lastdexf = nextdexf;
@@ -882,10 +884,10 @@ void ExactCallD::accumulateOneOpponentPossibleRaises(const int8 pIndex, ValueAnd
 
 
               #ifdef DEBUG_TRACE_DEXF
-              //if( traceOut != 0 )  *traceOut << " is " << totaldexf << ",  last added " << nextdexf << endl;
-              //if( traceOut != 0 )  *traceOut << " is " << totaldexf << endl;
-              //if( traceOut != 0 )  *traceOut << " last added " << nextdexf << endl;
-              //if( traceOut != 0 )  *traceOut << endl;
+              //if( traceOut_dexf != 0 )  *traceOut_dexf << " is " << totaldexf << ",  last added " << nextdexf << endl;
+              //if( traceOut_dexf != 0 )  *traceOut_dexf << " is " << totaldexf << endl;
+              //if( traceOut_dexf != 0 )  *traceOut_dexf << " last added " << nextdexf << endl;
+              //if( traceOut_dexf != 0 )  *traceOut_dexf << endl;
               #endif
 
 

--- a/holdem/src/callPrediction.h
+++ b/holdem/src/callPrediction.h
@@ -28,14 +28,9 @@
 #include "callSituation.h"
 
 #if defined(DEBUG_TRACE_PWIN) || defined(DEBUG_TRACE_DEXF)
-#define DEBUG_TRACE_EXACTCALL
-#else
-#undef DEBUG_TRACE_EXACTCALL
-#endif
-
-#ifdef DEBUG_TRACE_EXACTCALL
 #include <iostream>
 #endif
+
 
 // All values should be expressed as a fraction of your bankroll (so that Geom and Algb can be compared directly)
 // 1.0 is "no change"
@@ -114,7 +109,7 @@ class ExactCallD : public IExf
         return &(fCore.callcumu);
     }
 #ifdef DEBUG_TRACE_DEXF
-		std::ostream * traceOut;
+		std::ostream * traceOut_dexf;
 #endif
 
         ExactCallD(ExpectedCallD * const tbase //, CallCumulationD* data
@@ -130,7 +125,7 @@ class ExactCallD : public IExf
         //ed(data)
         fCore(core)
 #ifdef DEBUG_TRACE_DEXF
-					,traceOut(0)
+					,traceOut_dexf(0)
 #endif
             {
                 queryinput = UNINITIALIZED_QUERY;
@@ -191,7 +186,7 @@ class ExactCallBluffD
         void query(const float64 betSize);
 
     public:
-#ifdef DEBUG_TRACE_EXACTCALL
+#ifdef DEBUG_TRACE_PWIN
 		std::ostream * traceOut;
 #endif
 
@@ -202,7 +197,7 @@ class ExactCallBluffD
     tableinfo(tbase)
     ,
     fFoldCumu(core.foldcumu), fCallCumu(core.callcumu)
-    #ifdef DEBUG_TRACE_EXACTCALL
+    #ifdef DEBUG_TRACE_PWIN
 					,traceOut(0)
     #endif
     ,

--- a/holdem/src/callPredictionFunctions.h
+++ b/holdem/src/callPredictionFunctions.h
@@ -23,8 +23,9 @@
 #define HOLDEM_OpponentFunctions
 
 
-// #define DEBUG_TRACE_DEXF
-// ^^^ Enable if you need to trace through a specific search (usually you'll set `.traceOut = &logF` or whatever output sink, near where the issue occurs)
+// #define DEBUG_TRACE_DEXF 2
+// ^^^ Define if you need to trace through a specific search
+//     For example, if you are debugging `PureGainStrategy bot("abc.txt", 2)` you will want to `#define DEBUG_TRACE_DEXF 2`
 // ^^^ Disable (i.e. You can explicitly `#undef DEBUG_TRACE_DEXF`) if you don't want `.github/workflows/ci.yml` to test with it
 
 
@@ -385,5 +386,3 @@ class FacedOddsRaiseGeom : public virtual ScalarFunctionModel
 ;
 
 #endif
-
-

--- a/holdem/src/stratPosition.cpp
+++ b/holdem/src/stratPosition.cpp
@@ -1502,16 +1502,14 @@ float64 PureGainStrategy::MakeBet()
 
     const float64 bestBet = solveGainModel(&choicemodel);
 
-    #ifdef DEBUG_TRACE_DEXF
-      logFile << "└─> bGamble " << static_cast<int>(bGamble) << "'s result: $" << bestBet << "⛂" << std::endl;
-      pr_opponentcallraise.traceOut_dexf = nullptr;
-    #endif
-
 #ifdef LOGPOSITION
 
+  #ifdef DEBUG_TRACE_DEXF
+    logFile << "└─> bGamble " << static_cast<int>(bGamble) << "'s result: $" << bestBet << "⛂" << std::endl;
+    pr_opponentcallraise.traceOut_dexf = nullptr;
+  #endif
 
-
-#ifdef VERBOSE_STATEMODEL_INTERFACE
+  #ifdef VERBOSE_STATEMODEL_INTERFACE
     const float64 displaybet = (bestBet < betToCall) ? betToCall : bestBet;
 
     printFoldGain(choicemodel.f(displaybet), &(statprob.core.callcumu), tablestate);
@@ -1531,8 +1529,7 @@ float64 PureGainStrategy::MakeBet()
             printStateModel(logFile, displayMinRaise, ap_aggressive, ViewPlayer());
         }
     }
-
-#endif
+  #endif // VERBOSE_STATEMODEL_INTERFACE
 
     //if( bestBet < betToCall + ViewTable().GetChipDenom() )
     {

--- a/holdem/src/stratPosition.cpp
+++ b/holdem/src/stratPosition.cpp
@@ -1493,11 +1493,21 @@ float64 PureGainStrategy::MakeBet()
 
     HoldemFunctionModel& choicemodel = ap_aggressive;
 
+    #if defined(DEBUG_TRACE_DEXF) && defined(LOGPOSITION)
+      if (bGamble == DEBUG_TRACE_DEXF) {
+        logFile << "SOLVING E[x] for bGamble=" << static_cast<int>(bGamble) << std::endl;
+        pr_opponentcallraise.traceOut_dexf = &logFile;
+      }
+    #endif
 
     const float64 bestBet = solveGainModel(&choicemodel);
 
-#ifdef LOGPOSITION
+    #ifdef DEBUG_TRACE_DEXF
+      logFile << "└─> bGamble " << static_cast<int>(bGamble) << "'s result: $" << bestBet << "⛂" << std::endl;
+      pr_opponentcallraise.traceOut_dexf = nullptr;
+    #endif
 
+#ifdef LOGPOSITION
 
 
 
@@ -1533,7 +1543,6 @@ float64 PureGainStrategy::MakeBet()
 
     }
 
-
     printBetGradient< StateModel >
     (logFile, pr_opponentcallraise, ea, ap_aggressive, tablestate, displaybet, &csrp);
 
@@ -1545,6 +1554,7 @@ float64 PureGainStrategy::MakeBet()
     {
         logFile << "if playstyle is Danger/Conservative, overall utility is " << choicemodel.f(displaybet) << endl;
     }
+
 
 #endif // LOGPOSITION
 

--- a/holdem/unittests/main.cpp
+++ b/holdem/unittests/main.cpp
@@ -2263,7 +2263,7 @@ namespace RegressionTests {
 
         const playernumber_t highbettor = myTable.PlayRound_River(myFlop, myTurn, myRiver, std::cout);
         assert(highbettor == 4);
-        // No all-fold; assert that the pot was increased at least.
+        // No all-fold; assert that the pot was increased at least. ActionBot18 has Jd Ac so that's trip Aces. You're really going to check down the river??
         assert(myTable.GetPotSize() > 55);
 
 
@@ -4110,7 +4110,8 @@ Playing as S
 
         std::vector<float64> bbOnly; bbOnly.push_back(b.GetBigBlind()); bbOnly.push_back(0.0); bbOnly.push_back(0.0); bbOnly.push_back(0.0); bbOnly.push_back(0.0);
         const std::vector<float64> foldOnly(1, 0.0);
-        static const float64 arr[] = {5.0, 12.5, 49.0, 100.0, 228.0, 459.0, 495.0};
+        // static const float64 arr[] = {5.0, 12.5, 49.0, 100.0, 228.0, 459.0, 495.0};
+        static const float64 arr[] = {5.0, 12.5, 49.0, std::numeric_limits<float64>::signaling_NaN(), 228.0, 459.0, 495.0};
         const std::vector<float64> pA(arr, arr + sizeof(arr) / sizeof(arr[0]) );
 
         FixedReplayPlayerStrategy cS(foldOnly);
@@ -4219,6 +4220,7 @@ Playing as S
         if (highbet == -1) {
             // all-fold?
             assert(myTable.ViewPlayer(0)->GetBetSize() < 0); // SpaceBot should be the one that folded.
+            // If you see that Nav folded, raise Nav's pre-recorded bet to ensure he stays in the game.
         } else
         {
         /*


### PR DESCRIPTION
Need to do some A/B comparisons of https://github.com/yuzisee/pokeroo/pull/90 so this should shrink the diff, some.

From there, we can probably add a `#define OLD_BROKEN_RISKLOSS` that toggles the one function we're changing and nothing else