### PR TITLE
Reorder lines of code to make it more obvious what is missing

### DIFF
--- a/holdem/src/callPredictionFunctions.h
+++ b/holdem/src/callPredictionFunctions.h
@@ -364,8 +364,7 @@ class FacedOddsRaiseGeom : public virtual ScalarFunctionModel
 {
     protected:
     float64 lastW;
-    float64 lastF;
-    float64 lastFD;
+    ValueAndSlope lastF_by_w;
     void query( const float64 w );
     public:
     float64 raisedPot;

--- a/holdem/src/math_support.h
+++ b/holdem/src/math_support.h
@@ -75,6 +75,14 @@ struct ValueAndSlope {
     };
   }
 
+  constexpr ValueAndSlope operator+(const ValueAndSlope &a) const {
+    float64 addition_sum_v = this->v + a.v;
+    float64 addition_sum_d_v = this->D_v + a.D_v;
+    return ValueAndSlope{
+      addition_sum_v, addition_sum_d_v
+    };
+  }
+
   static constexpr ValueAndSlope sum3(const ValueAndSlope &a, const ValueAndSlope &b, const ValueAndSlope &c) {
     float64 addition_sum_v = a.v + b.v + c.v;
     float64 addition_sum_d_v = a.D_v + b.D_v + c.D_v;


### PR DESCRIPTION
Again, no functional change. 

This sets up the following experiments:

- [ ] Switch to `callGain` from `callIncrLoss * std::pow(callIncrBase,fw)` to `std::pow(callIncrLoss, 1 - fw) * std::pow(callIncrBase,fw)` (and associated derivative)
- [ ] Unify the conditions for `-= nonRaiseGain`
- [ ] Consider whether `applyRiskLoss / FG.waitLength.bankroll` has a derivative with respect to `w` (or you can use `dRiskLoss_dBetSize ⋅ dBetSize_dw`)
- [ ] And then, anything else left behind _REFINED_FACED_ODDS_RAISE_GEOM_
- [ ] AND THEN finally, anything left behind _OLD_BROKEN_RISKLOSS_WRONG_SIGN_