### PR TITLE
This test triggers when we try to fix `callGain`

### DIFF
--- a/holdem/src/arenaEvents.cpp
+++ b/holdem/src/arenaEvents.cpp
@@ -542,7 +542,6 @@ HoldemAction HoldemArenaBetting::MakeBet(float64 betSize, struct MinRaiseError *
 				}
                     randRem /= curIndex - myPot;
 
-
 			}
 			else if( PlayerAllIn(withP) > 0 )
 			{   ///If you are going all in with LESS money than to call
@@ -553,13 +552,9 @@ HoldemAction HoldemArenaBetting::MakeBet(float64 betSize, struct MinRaiseError *
                     randRem *= (myBetSum)/(curIndex+2.5);
 			}
 
-
-
-
-        do
+    do
 		{
 		    incrPlayerNumber(*(p[curIndex]));
-
 
             if(readyToFinish())
             {

--- a/holdem/src/callPredictionFunctions.cpp
+++ b/holdem/src/callPredictionFunctions.cpp
@@ -763,6 +763,7 @@ template<typename T> void FacedOddsRaiseGeom<T>::configure_with(FacedOddsRaiseGe
   a.raisedPot = cps.pot + (hypotheticalRaise.bWillGetCalled ? (hypotheticalRaise.betIncrease()) : 0);
     a.raiseTo = hypotheticalRaise.hypotheticalRaiseTo;
     a.fold_bet = hypotheticalRaise.fold_bet();
+    a.faced_bet = hypotheticalRaise.faced_bet();
     a.bCheckPossible = hypotheticalRaise.bCouldHaveChecked();
     a.riskLoss = currentRiskLoss;
   a.bRaiseWouldBeCalled = hypotheticalRaise.bWillGetCalled;
@@ -839,12 +840,22 @@ template<typename T> void FacedOddsRaiseGeom<T>::query( const float64 w )
         excess_by_w.D_v += FG.waitLength.d_dw(FG.n)/FG.waitLength.bankroll;
     }
 
-    const float64 callIncrLoss = 1 - this->fold_bet / FG.waitLength.bankroll;
-    const float64 callIncrBase = (FG.waitLength.bankroll + callPot)/(FG.waitLength.bankroll - this->fold_bet); // = 1 + (pot - fold_bet) / (bankroll - fold_bet);
-
   //We need to compare raising to the opportunity cost of calling/folding
 	//Depending on whether call or fold is more profitable, we choose the most significant opportunity cost
 #ifdef REFINED_FACED_ODDS_RAISE_GEOM
+  // If we were to _call_ instead of raising to `raiseTo`, what would our Geom gain be?
+  // Your current bankroll (i.e. the maximum that `raiseTo - fold_bet` could be) is:
+  //   `FG.waitLength.bankroll - this->fold_bet`
+  // If you win the hand by calling, you'll get everything in the pot:
+  //  + Bankroll after calling: `FG.waitLength.bankroll - this->faced_bet`
+  //  + You get back all the chips you put in, before this: `this->fold_bet`
+  //  + You also get back all the new chips you're putting in to call the bet: `faced_bet - fold_bet`
+  //  + You also get back everyone else's (where previous round chips are considered "someone else's") chips that are in the pot: `this->pot - this->fold_bet`
+  //  = FG.waitLength.bankroll - this->fold_bet + this->pot
+  // If you lose the hand by calling, you'll end up with
+  //   `FG.waitLength.bankroll - this->faced_bet`
+  const float64 callIncrLoss = (FG.waitLength.bankroll - this->faced_bet) / (FG.waitLength.bankroll - this->fold_bet);
+  const float64 callIncrBase = (FG.waitLength.bankroll - this->fold_bet + callPot)/(FG.waitLength.bankroll - this->fold_bet);
   const float64 callGain = std::pow(callIncrLoss, 1 - fw) * std::pow(callIncrBase,fw);
 
 
@@ -853,6 +864,8 @@ template<typename T> void FacedOddsRaiseGeom<T>::query( const float64 w )
 	// And then you should still set bUseCall accordingly, in that case
 
 #else
+  const float64 callIncrLoss = 1 - this->fold_bet / FG.waitLength.bankroll;
+  const float64 callIncrBase = (FG.waitLength.bankroll + callPot)/(FG.waitLength.bankroll - this->fold_bet); // = 1 + (pot + fold_bet) / (bankroll - fold_bet);
   const float64 applyRiskLoss =  (bCheckPossible) ? 0 : riskLoss;
 
 	const float64 callGain =

--- a/holdem/src/callPredictionFunctions.cpp
+++ b/holdem/src/callPredictionFunctions.cpp
@@ -854,8 +854,10 @@ template<typename T> void FacedOddsRaiseGeom<T>::query( const float64 w )
   //  = FG.waitLength.bankroll - this->fold_bet + this->pot
   // If you lose the hand by calling, you'll end up with
   //   `FG.waitLength.bankroll - this->faced_bet`
-  const float64 callIncrLoss = (FG.waitLength.bankroll - this->faced_bet) / (FG.waitLength.bankroll - this->fold_bet);
-  const float64 callIncrBase = (FG.waitLength.bankroll - this->fold_bet + callPot)/(FG.waitLength.bankroll - this->fold_bet);
+  const float64 callWin = (FG.waitLength.bankroll - this->fold_bet + callPot);
+  const float64 callLoss = (FG.waitLength.bankroll - this->faced_bet);
+  const float64 callIncrLoss = callLoss / (FG.waitLength.bankroll - this->fold_bet);
+  const float64 callIncrBase = callWin / (FG.waitLength.bankroll - this->fold_bet);
   const float64 callGain = std::pow(callIncrLoss, 1 - fw) * std::pow(callIncrBase,fw);
 
 

--- a/holdem/src/callPredictionFunctions.cpp
+++ b/holdem/src/callPredictionFunctions.cpp
@@ -877,8 +877,13 @@ template<typename T> void FacedOddsRaiseGeom<T>::query( const float64 w )
 				// (1/y) * dy/dw =  ln(callIncrBase) * dfw    - (ln callIncrLoss) * dfw
 				// (1/y) * dy/dw =    dfw * (ln(callIncrBase) - ln(callIncrLoss))
 				//         dy/dw = y * dfw * (ln(callIncrBase) - ln(callIncrLoss))
+				//         dy/dw = y * dfw * (ln(callIncrBase/callIncrLoss))
+				//         dy/dw = y * dfw * (ln(1 + callIncrBase/callIncrLoss - 1))
+				//         dy/dw = y * dfw * (ln1p(callIncrBase/callIncrLoss - 1))
+				//         dy/dw = y * dfw * (ln1p((callIncrBase-callIncrLoss)/callIncrLoss))
 				#ifdef REFINED_FACED_ODDS_RAISE_GEOM
-					/*const float64 dL_dw =*/ callGain * dfw * (std::log(callIncrBase) - std::log(callIncrLoss))
+					callGain * dfw * stable_ln_div(callIncrBase, callIncrLoss)
+					// We use the `std::log1p(…) formulation to ensure numerical stability in the extreme case when `callIncrBase` could be quite large whereas `callIncrLoss` could be quite small
 				#else
 					/*const float64 dL_dw =*/ dfw*std::log1p(callIncrBase) * callGain
 				#endif

--- a/holdem/src/callPredictionFunctions.h
+++ b/holdem/src/callPredictionFunctions.h
@@ -371,6 +371,7 @@ class FacedOddsRaiseGeom : public virtual ScalarFunctionModel
     float64 callPot;
     float64 raiseTo;
     float64 fold_bet; // if I "fold" instead of `raiseTo`, what bet can we get back to just by waiting?
+    float64 faced_bet; // if I "call", I increase my bet **to** `faced_bet` (i.e. increase my bet **by** `faced_bet - fold_bet`)
     float64 riskLoss; // This is an adjustment being made by `ExpectedCallD::RiskLoss` and if it's negative it means the HypotheticalBet under consideration is taking too much risk
 	  bool bRaiseWouldBeCalled; // If this is `true`, at least *one* person will cause the raise (you won't get an all-fold situation)
     bool bCheckPossible;

--- a/holdem/src/math_support.h
+++ b/holdem/src/math_support.h
@@ -13,6 +13,16 @@
 #include <cmath>
 #include <limits>
 
+// @return ln(a/b) = ln(a) - ln(b)
+constexpr float64 stable_ln_div(float64 a, float64 b) {
+  const float64 delta = (a - b) / b;                     // = r−1
+  if (std::fabs(delta) <= std::sqrt(std::numeric_limits<float64>::epsilon())) {
+    // at roughly √ε at least half the mantissa is retained after subtraction, so the log1p approach is 5~6 decimal digits more accurate
+    return std::log1p(delta);                   // best accuracy
+  } else {
+    return std::log(a) - std::log(b);
+  }
+}
 
 struct ValueAndSlope {
   float64 v;

--- a/holdem/src/stratPosition.cpp
+++ b/holdem/src/stratPosition.cpp
@@ -450,16 +450,16 @@ void PositionalStrategy::printFoldGain(float64 raiseGain, CommunityStatsCdf * e,
     std::pair<float64, float64> foldgainVal_xw = foldGainCalculator.myFoldGainAndWaitlength(foldGainCalculator.suggestMeanOrRank());
     const float64 &foldgainVal = foldgainVal_xw.first; // gain
     const float64 &xw = foldgainVal_xw.second; // waitlength (in total hands dealt)
-    logFile << "FoldGain()";
+    logFile << "FoldGain";
     switch (foldGainCalculator.suggestMeanOrRank()) {
         case MEAN:
-            logFile << "M";
+            logFile << "ₘ";
             break;
         case RANK:
-            logFile << "R";
+            logFile << "ᵣ";
             break;
     }
-    logFile << "=" << foldgainVal;
+    logFile << "()=" << foldgainVal;
 
     float64 numfolds = xw * e->Pr_haveWinPCT_strictlyBetterThan(statprob.core.statmean.pct - EPS_WIN_PCT); // waitlength (in folds)
 

--- a/holdem/unittests/main.cpp
+++ b/holdem/unittests/main.cpp
@@ -1034,7 +1034,7 @@ namespace RegressionTests {
             return proceedWithBet(bets[i-1]);
         }
 
-        void assertMyPositionIndex(playernumber_t pIndex) {
+        void assertMyPositionIndex(playernumber_t pIndex) const {
           if (pIndex != this->myPositionIndex) {
             std::cerr << "Expecting WhoIsNext to be " << static_cast<int>(pIndex) << " but I'm " << static_cast<int>(this->myPositionIndex) << std::endl;
             assert(pIndex == myPositionIndex);

--- a/holdem/unittests/playlogs.expected/11.txt
+++ b/holdem/unittests/playlogs.expected/11.txt
@@ -32,7 +32,7 @@ Choice Optimal 10
 Choice Fold 10
 f(10)=0.996865
 CHECK/FOLD
-FoldGain()R=0.999074 by waiting 0 hands(=0 folds)	vs play:0.995939   ->assumes $5 forced
+FoldGainᵣ()=0.999074 by waiting 0 hands(=0 folds)	vs play:0.995939   ->assumes $5 forced
  AgainstCall(10)=1.00058 from +$2.82672 @ 0.305634
 AgainstRaise(10)=0.995366 from -$10 @ 0.694366
         Push(10)=1 from $0 @ 0

--- a/holdem/unittests/playlogs.expected/12.txt
+++ b/holdem/unittests/playlogs.expected/12.txt
@@ -32,7 +32,7 @@ Choice Optimal 10
 Choice Fold 15
 f(10)=1.11899
 CALL 10
-FoldGain()R=0.999074 by waiting 0 hands(=0 folds)	vs play:1.11807
+FoldGainᵣ()=0.999074 by waiting 0 hands(=0 folds)	vs play:1.11807
  AgainstCall(10)=1.00616 from +$13.1972 @ 0.700335
 AgainstRaise(10)=1.11191 from +$560.155 @ 0.299665
         Push(10)=1 from $0 @ 0
@@ -97,7 +97,7 @@ Choice Optimal 0
 Choice Fold 40
 f(0)=1.01487
 CALL 0
-FoldGain()M=0.993289 by waiting 0 hands(=0 folds)	vs play:1.00815
+FoldGainₘ()=0.993289 by waiting 0 hands(=0 folds)	vs play:1.00815
  AgainstCall(0)=1.00815 from +$12.2535 @ 0.991597
 AgainstRaise(0)=1 from $0 @ 0.00840271
         Push(0)=1 from $0 @ 0
@@ -162,7 +162,7 @@ Choice Optimal 0
 Choice Fold 110
 f(0)=1.01957
 CALL 0
-FoldGain()M=0.993289 by waiting 0 hands(=0 folds)	vs play:1.01286
+FoldGainₘ()=0.993289 by waiting 0 hands(=0 folds)	vs play:1.01286
  AgainstCall(0)=1.01286 from +$19.1579 @ 1
 AgainstRaise(0)=1 from $0 @ 0
         Push(0)=1 from $0 @ 0
@@ -216,7 +216,7 @@ Choice Optimal 10
 Choice Fold 75
 f(10)=1.02413
 CALL 10
-FoldGain()M=0.993289 by waiting 0 hands(=0 folds)	vs play:1.01742
+FoldGainₘ()=0.993289 by waiting 0 hands(=0 folds)	vs play:1.01742
  AgainstCall(10)=1.01742 from +$25.9545 @ 1
 AgainstRaise(10)=1 from $0 @ 0
         Push(10)=1 from $0 @ 0

--- a/holdem/unittests/playlogs.expected/13a.txt
+++ b/holdem/unittests/playlogs.expected/13a.txt
@@ -32,7 +32,7 @@ Choice Optimal 55
 Choice Fold 55
 f(55)=1.00634
 CALL 55
-FoldGain()R=0.999148 by waiting 0 hands(=0 folds)	vs play:1.00549   ->assumes $10 forced
+FoldGainᵣ()=0.999148 by waiting 0 hands(=0 folds)	vs play:1.00549   ->assumes $10 forced
  AgainstCall(55)=1.00549 from +$8.94816 @ 1
 AgainstRaise(55)=1 from $0 @ 0
         Push(55)=1 from $0 @ 0

--- a/holdem/unittests/playlogs.expected/14a.txt
+++ b/holdem/unittests/playlogs.expected/14a.txt
@@ -34,7 +34,7 @@ f(10)=1.01947
 *MinRaise 20
 RAISETO 20
 
-FoldGain()R=0.998285 by waiting 0 hands(=0 folds)	vs play:1.01934   ->assumes $5 forced
+FoldGainᵣ()=0.998285 by waiting 0 hands(=0 folds)	vs play:1.01934   ->assumes $5 forced
  AgainstCall(20)=1.00311 from +$12.8156 @ 0.197736
 AgainstRaise(20)=1.01122 from +$20.1184 @ 0.454814
         Push(20)=1.00491 from +$11.4893 @ 0.347449
@@ -88,7 +88,7 @@ Choice Optimal 365
 Choice Fold 460
 f(365)=1.31048
 CALL 365
-FoldGain()R=0.981481 by waiting 0 hands(=0 folds)	vs play:1.29196   ->assumes $5 forced
+FoldGainᵣ()=0.981481 by waiting 0 hands(=0 folds)	vs play:1.29196   ->assumes $5 forced
  AgainstCall(365)=1.29196 from +$236.488 @ 1
 AgainstRaise(365)=1 from $0 @ 0
         Push(365)=1 from $0 @ 0

--- a/holdem/unittests/playlogs.expected/17.txt
+++ b/holdem/unittests/playlogs.expected/17.txt
@@ -32,7 +32,7 @@ Choice Optimal 10
 Choice Fold 15
 f(10)=1.04334
 CALL 10
-FoldGain()R=0.999076 by waiting 0 hands(=0 folds)	vs play:1.04242
+FoldGainᵣ()=0.999076 by waiting 0 hands(=0 folds)	vs play:1.04242
  AgainstCall(10)=1.00668 from +$12.8346 @ 0.781555
 AgainstRaise(10)=1.03574 from +$245.853 @ 0.218445
         Push(10)=1 from $0 @ 0
@@ -97,7 +97,7 @@ Choice Optimal 0
 Choice Fold 15
 f(0)=1.01061
 CALL 0
-FoldGain()R=0.9933 by waiting 0 hands(=0 folds)	vs play:1.00391
+FoldGainᵣ()=0.9933 by waiting 0 hands(=0 folds)	vs play:1.00391
  AgainstCall(0)=1.00391 from +$10.3273 @ 0.564564
 AgainstRaise(0)=1 from $0 @ 0.435436
         Push(0)=1 from $0 @ 0
@@ -162,7 +162,7 @@ Choice Optimal 0
 Choice Fold 20
 f(0)=1.01158
 CALL 0
-FoldGain()R=0.9933 by waiting 0 hands(=0 folds)	vs play:1.00488
+FoldGainᵣ()=0.9933 by waiting 0 hands(=0 folds)	vs play:1.00488
  AgainstCall(0)=1.00488 from +$9.59986 @ 0.757927
 AgainstRaise(0)=1 from $0 @ 0.242073
         Push(0)=1 from $0 @ 0
@@ -218,7 +218,7 @@ f(0)=1.15546
 *MinRaise 10
 RAISETO 21.582
 
-FoldGain()R=0.9933 by waiting 0 hands(=0 folds)	vs play:1.34534
+FoldGainᵣ()=0.9933 by waiting 0 hands(=0 folds)	vs play:1.34534
  AgainstCall(21.582)=1.01928 from +$85.4488 @ 0.3367
 AgainstRaise(21.582)=1.32031 from +$998.693 @ 0.478688
         Push(21.582)=1.00575 from +$46.4822 @ 0.184613

--- a/holdem/unittests/playlogs.expected/18.txt
+++ b/holdem/unittests/playlogs.expected/18.txt
@@ -32,7 +32,7 @@ Choice Optimal 10
 Choice Fold 10
 f(10)=1.00201
 CALL 10
-FoldGain()R=0.999077 by waiting 0 hands(=0 folds)	vs play:1.00109   ->assumes $5 forced
+FoldGainᵣ()=0.999077 by waiting 0 hands(=0 folds)	vs play:1.00109   ->assumes $5 forced
  AgainstCall(10)=1.00467 from +$15.2121 @ 0.463729
 AgainstRaise(10)=0.996431 from -$10 @ 0.536271
         Push(10)=1 from $0 @ 0
@@ -97,7 +97,7 @@ Choice Optimal 0
 Choice Fold 15
 f(0)=1.00862
 CALL 0
-FoldGain()R=0.993311 by waiting 0 hands(=0 folds)	vs play:1.00193
+FoldGainᵣ()=0.993311 by waiting 0 hands(=0 folds)	vs play:1.00193
  AgainstCall(0)=1.00193 from +$9.67878 @ 0.298737
 AgainstRaise(0)=1 from $0 @ 0.701263
         Push(0)=1 from $0 @ 0
@@ -162,7 +162,7 @@ Choice Optimal 0
 Choice Fold 30
 f(0)=1.0155
 CALL 0
-FoldGain()R=0.993311 by waiting 0 hands(=0 folds)	vs play:1.00881
+FoldGainᵣ()=0.993311 by waiting 0 hands(=0 folds)	vs play:1.00881
  AgainstCall(0)=1.00881 from +$25.8636 @ 0.511171
 AgainstRaise(0)=1 from $0 @ 0.488829
         Push(0)=1 from $0 @ 0
@@ -218,7 +218,7 @@ f(0)=1.02173
 *MinRaise 10
 RAISETO 10
 
-FoldGain()R=0.993311 by waiting 0 hands(=0 folds)	vs play:1.01847
+FoldGainᵣ()=0.993311 by waiting 0 hands(=0 folds)	vs play:1.01847
  AgainstCall(10)=1.01477 from +$42.6365 @ 0.521472
 AgainstRaise(10)=1.00364 from +$11.3958 @ 0.478528
         Push(10)=1 from $0 @ 0

--- a/holdem/unittests/playlogs.expected/19.txt
+++ b/holdem/unittests/playlogs.expected/19.txt
@@ -32,7 +32,7 @@ Choice Optimal 10
 Choice Fold 15
 f(10)=1.02475
 CALL 10
-FoldGain()R=0.999077 by waiting 0 hands(=0 folds)	vs play:1.02382   ->assumes $5 forced
+FoldGainᵣ()=0.999077 by waiting 0 hands(=0 folds)	vs play:1.02382   ->assumes $5 forced
  AgainstCall(10)=1.00042 from +$1.20403 @ 0.531281
 AgainstRaise(10)=1.02339 from +$76.0939 @ 0.468719
         Push(10)=1 from $0 @ 0

--- a/holdem/unittests/playlogs.expected/2.txt
+++ b/holdem/unittests/playlogs.expected/2.txt
@@ -32,7 +32,7 @@ Choice Optimal 2.25
 Choice Fold 2.25
 f(2.25)=0.998954
 CHECK/FOLD
-FoldGain()R=0.999522 by waiting 0 hands(=0 folds)	vs play:0.998476
+FoldGainᵣ()=0.999522 by waiting 0 hands(=0 folds)	vs play:0.998476
  AgainstCall(2.25)=1.00073 from +$1.83715 @ 0.283732
 AgainstRaise(2.25)=0.997751 from -$2.25 @ 0.716268
         Push(2.25)=1 from $0 @ 0

--- a/holdem/unittests/playlogs.expected/21.txt
+++ b/holdem/unittests/playlogs.expected/21.txt
@@ -32,7 +32,7 @@ Choice Optimal 2
 Choice Fold 2
 f(2)=0.999358
 CHECK/FOLD
-FoldGain()R=0.999883 by waiting 0 hands(=0 folds)	vs play:0.999241
+FoldGainᵣ()=0.999883 by waiting 0 hands(=0 folds)	vs play:0.999241
  AgainstCall(2)=0.999928 from -$1.74469 @ 0.107108
 AgainstRaise(2)=0.999313 from -$2 @ 0.892892
         Push(2)=1 from $0 @ 0

--- a/holdem/unittests/playlogs.expected/21b.txt
+++ b/holdem/unittests/playlogs.expected/21b.txt
@@ -45,7 +45,7 @@ f(0)=1.00138
 *MinRaise 2
 RAISETO 2
 
-FoldGain()R=0.99923 by waiting 0 hands(=0 folds)	vs play:1.00088
+FoldGainᵣ()=0.99923 by waiting 0 hands(=0 folds)	vs play:1.00088
  AgainstCall(2)=1.00129 from +$7.18577 @ 0.467369
 AgainstRaise(2)=0.99959 from -$2 @ 0.532631
         Push(2)=1 from $0 @ 0
@@ -102,7 +102,7 @@ Choice Optimal 20
 Choice Fold 21
 f(20)=1.00015
 CALL 20
-FoldGain()R=0.99846 by waiting 0 hands(=0 folds)	vs play:0.998607
+FoldGainᵣ()=0.99846 by waiting 0 hands(=0 folds)	vs play:0.998607
  AgainstCall(20)=1.00038 from +$1.28532 @ 0.770296
 AgainstRaise(20)=0.998226 from -$20 @ 0.229704
         Push(20)=1 from $0 @ 0
@@ -163,7 +163,7 @@ Choice Optimal 0
 Choice Fold 72
 f(0)=1.01328
 CALL 0
-FoldGain()R=0.991466 by waiting 0 hands(=0 folds)	vs play:1.00475
+FoldGainᵣ()=0.991466 by waiting 0 hands(=0 folds)	vs play:1.00475
  AgainstCall(0)=1.00539 from +$25.7691 @ 0.54071
 AgainstRaise(0)=0.999358 from -$3.60189 @ 0.45929
         Push(0)=1 from $0 @ 0
@@ -219,7 +219,7 @@ Choice Optimal 0
 Choice Fold 17
 f(0)=1.00659
 CALL 0
-FoldGain()R=0.991466 by waiting 0 hands(=0 folds)	vs play:0.998058
+FoldGainᵣ()=0.991466 by waiting 0 hands(=0 folds)	vs play:0.998058
  AgainstCall(0)=1.0005 from +$4.92027 @ 0.264101
 AgainstRaise(0)=0.997555 from -$8.56134 @ 0.735899
         Push(0)=1 from $0 @ 0

--- a/holdem/unittests/playlogs.expected/22.txt
+++ b/holdem/unittests/playlogs.expected/22.txt
@@ -32,7 +32,7 @@ Choice Optimal 2
 Choice Fold 3
 f(2)=1.00596
 CALL 2
-FoldGain()R=0.999391 by waiting 0 hands(=0 folds)	vs play:1.00535   ->assumes $1 forced
+FoldGainᵣ()=0.999391 by waiting 0 hands(=0 folds)	vs play:1.00535   ->assumes $1 forced
  AgainstCall(2)=1.00781 from +$10.1221 @ 0.385632
 AgainstRaise(2)=0.997543 from -$2 @ 0.614368
         Push(2)=1 from $0 @ 0
@@ -99,7 +99,7 @@ f(0)=1.0255
 *MinRaise 2
 RAISETO 2
 
-FoldGain()R=0.995984 by waiting 0 hands(=0 folds)	vs play:1.02875
+FoldGainᵣ()=0.995984 by waiting 0 hands(=0 folds)	vs play:1.02875
  AgainstCall(2)=1.02885 from +$20.9022 @ 0.687325
 AgainstRaise(2)=0.999901 from -$0.157697 @ 0.312675
         Push(2)=1 from $0 @ 0
@@ -165,7 +165,7 @@ Choice Optimal 0
 Choice Fold 72
 f(0)=1.02433
 CALL 0
-FoldGain()R=0.991935 by waiting 0 hands(=0 folds)	vs play:1.01627
+FoldGainᵣ()=0.991935 by waiting 0 hands(=0 folds)	vs play:1.01627
  AgainstCall(0)=1.01627 from +$18.3078 @ 0.440728
 AgainstRaise(0)=1 from $0 @ 0.559272
         Push(0)=1 from $0 @ 0
@@ -219,7 +219,7 @@ Choice Optimal 100
 Choice Fold 100
 f(100)=0.807867
 CHECK/FOLD
-FoldGain()R=1.21743 by waiting 168.333 hands(=14.7739 folds)	vs play:1.0253
+FoldGainᵣ()=1.21743 by waiting 168.333 hands(=14.7739 folds)	vs play:1.0253
  AgainstCall(100)=1.10921 from +$92.7833 @ 0.583814
 AgainstRaise(100)=0.916092 from -$100 @ 0.416186
         Push(100)=1 from $0 @ 0

--- a/holdem/unittests/playlogs.expected/25.txt
+++ b/holdem/unittests/playlogs.expected/25.txt
@@ -32,7 +32,7 @@ Choice Optimal 74.2857
 Choice Fold 74.2857
 f(74.2857)=-1.14259
 CHECK/FOLD
-FoldGain()R=2.3311 by waiting 31.3333 hands(=20.8463 folds)	vs play:0.188516
+FoldGainᵣ()=2.3311 by waiting 31.3333 hands(=20.8463 folds)	vs play:0.188516
  AgainstCall(74.2857)=0.188516 from -$60.2817 @ 1
 AgainstRaise(74.2857)=1 from $0 @ 0
         Push(74.2857)=1 from $0 @ 0

--- a/holdem/unittests/playlogs.expected/26.txt
+++ b/holdem/unittests/playlogs.expected/26.txt
@@ -32,7 +32,7 @@ Choice Optimal 20
 Choice Fold 20
 f(20)=1.0283
 CALL 20
-FoldGain()R=0.991582 by waiting 0 hands(=0 folds)	vs play:1.01988   ->assumes $2.85714 forced
+FoldGainᵣ()=0.991582 by waiting 0 hands(=0 folds)	vs play:1.01988   ->assumes $2.85714 forced
  AgainstCall(20)=1.02032 from +$2.11655 @ 0.905126
 AgainstRaise(20)=0.999561 from -$0.435866 @ 0.0948743
         Push(20)=1 from $0 @ 0
@@ -87,7 +87,7 @@ Choice Optimal 0
 Choice Fold 37.1428
 f(0)=1.30426
 CALL 0
-FoldGain()R=0.730769 by waiting 0 hands(=0 folds)	vs play:1.03503
+FoldGainᵣ()=0.730769 by waiting 0 hands(=0 folds)	vs play:1.03503
  AgainstCall(0)=1.08138 from +$11.0829 @ 0.545447
 AgainstRaise(0)=0.953651 from -$7.57466 @ 0.454553
         Push(0)=1 from $0 @ 0
@@ -133,7 +133,7 @@ Choice Optimal 32.8571
 Choice Fold 40
 f(32.8571)=1.21153
 CALL 32.8571
-FoldGain()R=0.730769 by waiting 0 hands(=0 folds)	vs play:0.942296
+FoldGainᵣ()=0.730769 by waiting 0 hands(=0 folds)	vs play:0.942296
  AgainstCall(32.8571)=0.942296 from -$4.28656 @ 1
 AgainstRaise(32.8571)=1 from $0 @ 0
         Push(32.8571)=1 from $0 @ 0
@@ -184,7 +184,7 @@ Choice Optimal 0
 Choice Fold 41.4286
 f(0)=3.09258
 CALL 0
-FoldGain()R=0 by waiting 0 hands(=0 folds)	vs play:2.09258
+FoldGainᵣ()=0 by waiting 0 hands(=0 folds)	vs play:2.09258
  AgainstCall(0)=1.93441 from +$46.8303 @ 0.826625
 AgainstRaise(0)=1.15817 from +$37.7962 @ 0.173375
         Push(0)=1 from $0 @ 0
@@ -228,7 +228,7 @@ Choice Optimal 0
 Choice Fold 41.4286
 f(0)=2.16812
 CALL 0
-FoldGain()R=0 by waiting 0 hands(=0 folds)	vs play:1.16812
+FoldGainᵣ()=0 by waiting 0 hands(=0 folds)	vs play:1.16812
  AgainstCall(0)=1.21009 from +$13.8955 @ 0.626384
 AgainstRaise(0)=0.958025 from -$4.65436 @ 0.373616
         Push(0)=1 from $0 @ 0

--- a/holdem/unittests/playlogs.expected/27.txt
+++ b/holdem/unittests/playlogs.expected/27.txt
@@ -33,7 +33,7 @@ Choice Fold 128
 f(108)=-2.0319
 raiseGain: f(128)=-2.0319
 CHECK/FOLD
-FoldGain()R=3.45147 by waiting 55 hands(=31.1592 folds)	vs play:0.419567
+FoldGainᵣ()=3.45147 by waiting 55 hands(=31.1592 folds)	vs play:0.419567
  AgainstCall(108)=1 from -$81.1731 @ 0
 AgainstRaise(108)=0.419567 from -$74.2955 @ 1
         Push(108)=1 from $0 @ 0

--- a/holdem/unittests/playlogs.expected/28.txt
+++ b/holdem/unittests/playlogs.expected/28.txt
@@ -32,7 +32,7 @@ Choice Optimal 4
 Choice Fold 6
 f(4)=1.05312
 CALL 4
-FoldGain()R=0.996793 by waiting 0 hands(=0 folds)	vs play:1.04991
+FoldGainᵣ()=0.996793 by waiting 0 hands(=0 folds)	vs play:1.04991
  AgainstCall(4)=1.01156 from +$3.29077 @ 0.737557
 AgainstRaise(4)=1.03836 from +$30.692 @ 0.262443
         Push(4)=1 from $0 @ 0
@@ -82,7 +82,7 @@ Choice Optimal 158
 Choice Fold 210
 f(158)=2.0278
 CALL 158
-FoldGain()R=0.980952 by waiting 0 hands(=0 folds)	vs play:2.00875
+FoldGainᵣ()=0.980952 by waiting 0 hands(=0 folds)	vs play:2.00875
  AgainstCall(158)=1 from +$211.838 @ 0
 AgainstRaise(158)=2.00875 from +$211.838 @ 1
         Push(158)=1 from $0 @ 0
@@ -132,7 +132,7 @@ Choice Optimal 0
 Choice Fold 52
 f(0)=4.61015
 CALL 0
-FoldGain()R=0 by waiting 0 hands(=0 folds)	vs play:3.61015
+FoldGainᵣ()=0 by waiting 0 hands(=0 folds)	vs play:3.61015
  AgainstCall(0)=3.55012 from +$136.011 @ 0.974964
 AgainstRaise(0)=1.06003 from +$124.677 @ 0.0250356
         Push(0)=1 from $0 @ 0
@@ -189,7 +189,7 @@ Choice Optimal 0
 Choice Fold 52
 f(0)=3.6125
 CALL 0
-FoldGain()R=0 by waiting 0 hands(=0 folds)	vs play:2.6125
+FoldGainᵣ()=0 by waiting 0 hands(=0 folds)	vs play:2.6125
  AgainstCall(0)=2.51797 from +$85.2937 @ 0.925442
 AgainstRaise(0)=1.09453 from +$65.9312 @ 0.0745576
         Push(0)=1 from $0 @ 0
@@ -235,7 +235,7 @@ Choice Optimal 0
 Choice Fold 52
 f(0)=2.68056
 CALL 0
-FoldGain()R=0 by waiting 0 hands(=0 folds)	vs play:1.68056
+FoldGainᵣ()=0 by waiting 0 hands(=0 folds)	vs play:1.68056
  AgainstCall(0)=1.5476 from +$44.7319 @ 0.636575
 AgainstRaise(0)=1.13295 from +$19.0236 @ 0.363425
         Push(0)=1 from $0 @ 0

--- a/holdem/unittests/playlogs.expected/4.txt
+++ b/holdem/unittests/playlogs.expected/4.txt
@@ -32,7 +32,7 @@ Choice Optimal 2
 Choice Fold 2
 f(2)=1.00006
 CALL 2
-FoldGain()R=0.999816 by waiting 0 hands(=0 folds)	vs play:0.999876
+FoldGainᵣ()=0.999816 by waiting 0 hands(=0 folds)	vs play:0.999876
  AgainstCall(2)=1.00063 from +$2.19943 @ 0.431709
 AgainstRaise(2)=0.999246 from -$2 @ 0.568291
         Push(2)=1 from $0 @ 0
@@ -90,7 +90,7 @@ Choice Optimal 5
 Choice Fold 8
 f(5)=1.00162
 CALL 5
-FoldGain()R=0.998673 by waiting 0 hands(=0 folds)	vs play:1.00029
+FoldGainᵣ()=0.998673 by waiting 0 hands(=0 folds)	vs play:1.00029
  AgainstCall(5)=1.00065 from +$1.09228 @ 0.892138
 AgainstRaise(5)=0.999642 from -$5 @ 0.107862
         Push(5)=1 from $0 @ 0
@@ -157,7 +157,7 @@ Choice Optimal 0
 Choice Fold 32
 f(0)=1.0089
 CALL 0
-FoldGain()M=0.996671 by waiting 0 hands(=0 folds)	vs play:1.00557
+FoldGainₘ()=0.996671 by waiting 0 hands(=0 folds)	vs play:1.00557
  AgainstCall(0)=1.00557 from +$9.10248 @ 0.919189
 AgainstRaise(0)=1 from $0 @ 0.0808111
         Push(0)=1 from $0 @ 0
@@ -226,7 +226,7 @@ Choice Optimal 0
 Choice Fold 24
 f(0)=1.0083
 CALL 0
-FoldGain()M=0.996671 by waiting 0 hands(=0 folds)	vs play:1.00497
+FoldGainₘ()=0.996671 by waiting 0 hands(=0 folds)	vs play:1.00497
  AgainstCall(0)=1.00497 from +$8.92959 @ 0.836555
 AgainstRaise(0)=1 from $0 @ 0.163445
         Push(0)=1 from $0 @ 0
@@ -286,7 +286,7 @@ f(10)=1.01425
 *MinRaise 20
 RAISETO 21
 
-FoldGain()M=0.996671 by waiting 0 hands(=0 folds)	vs play:1.01099
+FoldGainₘ()=0.996671 by waiting 0 hands(=0 folds)	vs play:1.01099
  AgainstCall(21)=1.00789 from +$24.1303 @ 0.490814
 AgainstRaise(21)=1.00311 from +$9.16722 @ 0.509186
         Push(21)=1 from $0 @ 0
@@ -330,7 +330,7 @@ Choice Optimal 32
 Choice Fold 141
 f(32)=1.03852
 CALL 32
-FoldGain()M=0.98269 by waiting 0 hands(=0 folds)	vs play:1.02121
+FoldGainₘ()=0.98269 by waiting 0 hands(=0 folds)	vs play:1.02121
  AgainstCall(32)=1.02121 from +$31.8636 @ 1
 AgainstRaise(32)=1 from $0 @ 0
         Push(32)=1 from $0 @ 0

--- a/holdem/unittests/playlogs.expected/5.txt
+++ b/holdem/unittests/playlogs.expected/5.txt
@@ -32,7 +32,7 @@ Choice Optimal 10.125
 Choice Fold 10.125
 f(10.125)=0.994545
 CHECK/FOLD
-FoldGain()R=0.998972 by waiting 0 hands(=0 folds)	vs play:0.993516   ->assumes $10.125 forced
+FoldGainᵣ()=0.998972 by waiting 0 hands(=0 folds)	vs play:0.993516   ->assumes $10.125 forced
  AgainstCall(10.125)=0.999879 from -$3.15133 @ 0.0573914
 AgainstRaise(10.125)=0.993636 from -$10.125 @ 0.942609
         Push(10.125)=1 from $0 @ 0
@@ -97,7 +97,7 @@ Choice Optimal 0
 Choice Fold 9
 f(0)=1.00493
 CALL 0
-FoldGain()M=0.998965 by waiting 0 hands(=0 folds)	vs play:1.00389   ->assumes $10.125 forced
+FoldGainₘ()=0.998965 by waiting 0 hands(=0 folds)	vs play:1.00389   ->assumes $10.125 forced
  AgainstCall(0)=1.00389 from +$15.8633 @ 0.366943
 AgainstRaise(0)=1 from $0 @ 0.633057
         Push(0)=1 from $0 @ 0
@@ -151,7 +151,7 @@ Choice Optimal 18
 Choice Fold 22.5
 f(18)=1.00735
 CALL 18
-FoldGain()M=0.998965 by waiting 0 hands(=0 folds)	vs play:1.00631   ->assumes $10.125 forced
+FoldGainₘ()=0.998965 by waiting 0 hands(=0 folds)	vs play:1.00631   ->assumes $10.125 forced
  AgainstCall(18)=1.00979 from +$20.4245 @ 0.715787
 AgainstRaise(18)=0.996551 from -$18 @ 0.284213
         Push(18)=1 from $0 @ 0
@@ -214,7 +214,7 @@ Choice Optimal 0
 Choice Fold 40.5
 f(0)=1.02618
 CALL 0
-FoldGain()M=0.987771 by waiting 0 hands(=0 folds)	vs play:1.01395   ->assumes $10.125 forced
+FoldGainₘ()=0.987771 by waiting 0 hands(=0 folds)	vs play:1.01395   ->assumes $10.125 forced
  AgainstCall(0)=1.01167 from +$31.3146 @ 0.551156
 AgainstRaise(0)=1.00225 from +$7.39165 @ 0.448844
         Push(0)=1 from $0 @ 0
@@ -269,7 +269,7 @@ Choice Fold 1471.88
 f(805.5)=0.552341
 raiseGain: f(1471.88)=0.552341
 CHECK/FOLD
-FoldGain()M=1.31314 by waiting 36.6667 hands(=15.0177 folds)	vs play:0.865478   ->assumes $10.125 forced
+FoldGainₘ()=1.31314 by waiting 36.6667 hands(=15.0177 folds)	vs play:0.865478   ->assumes $10.125 forced
  AgainstCall(805.5)=1 from $0 @ 0
 AgainstRaise(805.5)=0.865478 from -$198 @ 1
         Push(805.5)=1 from $0 @ 0

--- a/holdem/unittests/playlogs.expected/6.txt
+++ b/holdem/unittests/playlogs.expected/6.txt
@@ -32,7 +32,7 @@ Choice Optimal 11.25
 Choice Fold 11.25
 f(11.25)=0.997184
 CHECK/FOLD
-FoldGain()R=0.999435 by waiting 0 hands(=0 folds)	vs play:0.996619   ->assumes $11.25 forced
+FoldGainᵣ()=0.999435 by waiting 0 hands(=0 folds)	vs play:0.996619   ->assumes $11.25 forced
  AgainstCall(11.25)=0.999888 from -$2.84284 @ 0.118936
 AgainstRaise(11.25)=0.99673 from -$11.25 @ 0.881064
         Push(11.25)=1 from $0 @ 0
@@ -97,7 +97,7 @@ Choice Optimal 0
 Choice Fold 5
 f(0)=1.00205
 CALL 0
-FoldGain()M=0.999433 by waiting 0 hands(=0 folds)	vs play:1.00149   ->assumes $11.25 forced
+FoldGainₘ()=0.999433 by waiting 0 hands(=0 folds)	vs play:1.00149   ->assumes $11.25 forced
  AgainstCall(0)=1.00149 from +$14.9326 @ 0.301006
 AgainstRaise(0)=1 from $0 @ 0.698994
         Push(0)=1 from $0 @ 0
@@ -129,6 +129,105 @@ OppRAISEChanceM [F] 0.0317148 @ $1440 ($52.672 now)	fold -- 0.764706	W(20×)=0.0
 OppRAISEChanceM [F] 0.00677199 @ $2228.75 ($61.3092 now)	fold -- 0.728507	W(17.5×)=0.0728305 L=0.81669 1×o.w_s=(0.0728305,0.11048)
 Guaranteed > $28.125 is in the pot for sure
 OppFoldChance% ...    0   ∇=0
+Spot Check: If you raise, you should expect to get re-raised over the next few rounds since your hand isn't _that_ good ┋ bGamble=0
+
+*
+3c Qc Bet to call 80 (from 0) at 108.125 pot, 
+Community outcomes (stdev = 0.125559 pcts , avgdev = 0.0865001 pcts ), kurtosis = 3.30048
+0.434497 pct: least helpful community
+0.446391 pct: 24 / 47 (51.0638%)
+0.530936 pct (mean): mean- 0.553191   mean+ 0.446809 (skew 1.96034 tail right) 
+0.549805 pct: 14 / 47 (29.7872%)
+0.591063 pct: 5 / 47 (10.6383%)
+0.671992 pct: 0 / 47 (0%)
+0.739847 pct: 0 / 47 (0%)
+0.807703 pct: 0 / 47 (0%)
+0.897011 pct: 4 / 47 (8.51064%)
+0.909486 pct: most helpful community
+CallStrength W(1m)=0.486948 L=0.425076 o.w_s=(0.486948,0.087976)
+(MinRaise to $160) 	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+ -  statranking algb RAW - 
+8 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 80
+Choice Fold 80
+f(80)=0.987159
+CHECK/FOLD
+FoldGainₘ()=1.00603 by waiting 16.6667 hands(=6.17914 folds)	vs play:0.99319   ->assumes $11.25 forced
+ AgainstCall(80)=1.00392 from +$19.8824 @ 0.594999
+AgainstRaise(80)=0.989274 from -$80 @ 0.405001
+        Push(80)=1 from $0 @ 0
+ AgainstCall(160)=1.00175 from +$24.8321 @ 0.212877
+AgainstRaise(160)=0.958307 from -$160 @ 0.787123
+        Push(160)=1 from $0 @ 0
+"all fold" precision will be 0.00452489
+OppRAISEChanceM [*] 0 @ $160 ($80 now)	fold -- 0.0	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+OppRAISEChanceM [*] 0 @ $240 ($80 now)	fold -- 0.0542986	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+OppRAISEChanceM [F] 0.405001 @ $400 ($92.0726 now)	fold -- 0.262443	W(5.16667×)=0.150036 L=0.809296 1×o.w_s=(0.150036,0.040668)
+OppRAISEChanceM [F] 0.197669 @ $720 ($126.258 now)	fold -- 0.511312	W(6.5×)=0.136528 L=0.815437 1×o.w_s=(0.136528,0.0480349)
+OppRAISEChanceM [F] 0.0776309 @ $1360 ($169.225 now)	fold -- 0.656109	W(8.5×)=0.118932 L=0.821856 1×o.w_s=(0.118932,0.0592124)
+OppRAISEChanceM [F] 0.00451977 @ $2228.75 ($207.748 now)	fold -- 0.651584	W(7.83333×)=0.123913 L=0.820583 1×o.w_s=(0.123913,0.0555043)
+
+(Fixed at $80)	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+	--
+Why didn't I raise to $160?
+"all fold" precision will be 0.00452489
+OppRAISEChanceM [*] 0.435862 @ $240 ($80 now)	fold -- 0.0542986	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+OppRAISEChanceM [F] 0.787123 @ $400 ($80 now)	fold -- 0.262443	W(5.16667×)=0.150036 L=0.809296 1×o.w_s=(0.150036,0.040668)
+OppRAISEChanceM [F] 0.556812 @ $720 ($119.064 now)	fold -- 0.511312	W(6.5×)=0.136528 L=0.815437 1×o.w_s=(0.136528,0.0480349)
+OppRAISEChanceM [F] 0.242647 @ $1360 ($164.75 now)	fold -- 0.656109	W(8.5×)=0.118932 L=0.821856 1×o.w_s=(0.118932,0.0592124)
+OppRAISEChanceM [F] 0.00677199 @ $2228.75 ($204.689 now)	fold -- 0.651584	W(7.83333×)=0.123913 L=0.820583 1×o.w_s=(0.123913,0.0555043)
+Guaranteed > $28.125 is in the pot for sure
+OppFoldChance% ...    0   ∇=0
+Spot Check: If you raise, you should expect to get re-raised over the next few rounds since your hand isn't _that_ good ┋ bGamble=1
+
+*
+3c Qc Bet to call 80 (from 0) at 108.125 pot, 
+Community outcomes (stdev = 0.125559 pcts , avgdev = 0.0865001 pcts ), kurtosis = 3.30048
+0.434497 pct: least helpful community
+0.446391 pct: 24 / 47 (51.0638%)
+0.530936 pct (mean): mean- 0.553191   mean+ 0.446809 (skew 1.96034 tail right) 
+0.549805 pct: 14 / 47 (29.7872%)
+0.591063 pct: 5 / 47 (10.6383%)
+0.671992 pct: 0 / 47 (0%)
+0.739847 pct: 0 / 47 (0%)
+0.807703 pct: 0 / 47 (0%)
+0.897011 pct: 4 / 47 (8.51064%)
+0.909486 pct: most helpful community
+CallStrength W(1m)=0.486948 L=0.425076 o.w_s=(0.486948,0.087976)
+(MinRaise to $160) 	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+ -  detailPCT  - 
+8 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 80
+Choice Fold 80
+f(80)=0.987026
+CHECK/FOLD
+FoldGainₘ()=1.00603 by waiting 16.6667 hands(=6.17914 folds)	vs play:0.993057   ->assumes $11.25 forced
+ AgainstCall(80)=1.00391 from +$19.8824 @ 0.594999
+AgainstRaise(80)=0.989188 from -$80 @ 0.405001
+        Push(80)=1 from $0 @ 0
+ AgainstCall(160)=1.00143 from +$20.2901 @ 0.212877
+AgainstRaise(160)=0.958067 from -$160 @ 0.787123
+        Push(160)=1 from $0 @ 0
+"all fold" precision will be 0.00452489
+OppRAISEChanceM [*] 0 @ $160 ($80 now)	fold -- 0.0	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+OppRAISEChanceM [*] 0 @ $240 ($80 now)	fold -- 0.0542986	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+OppRAISEChanceM [F] 0.405001 @ $400 ($92.0726 now)	fold -- 0.262443	W(5.16667×)=0.150036 L=0.809296 1×o.w_s=(0.150036,0.040668)
+OppRAISEChanceM [F] 0.197669 @ $720 ($126.258 now)	fold -- 0.511312	W(6.5×)=0.136528 L=0.815437 1×o.w_s=(0.136528,0.0480349)
+OppRAISEChanceM [F] 0.0776309 @ $1360 ($169.225 now)	fold -- 0.656109	W(8.5×)=0.118932 L=0.821856 1×o.w_s=(0.118932,0.0592124)
+OppRAISEChanceM [F] 0.00451977 @ $2228.75 ($207.748 now)	fold -- 0.651584	W(7.83333×)=0.123913 L=0.820583 1×o.w_s=(0.123913,0.0555043)
+
+(Fixed at $80)	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+	--
+Why didn't I raise to $160?
+"all fold" precision will be 0.00452489
+OppRAISEChanceM [*] 0.435862 @ $240 ($80 now)	fold -- 0.0542986	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+OppRAISEChanceM [F] 0.787123 @ $400 ($80 now)	fold -- 0.262443	W(5.16667×)=0.150036 L=0.809296 1×o.w_s=(0.150036,0.040668)
+OppRAISEChanceM [F] 0.556812 @ $720 ($119.064 now)	fold -- 0.511312	W(6.5×)=0.136528 L=0.815437 1×o.w_s=(0.136528,0.0480349)
+OppRAISEChanceM [F] 0.242647 @ $1360 ($164.75 now)	fold -- 0.656109	W(8.5×)=0.118932 L=0.821856 1×o.w_s=(0.118932,0.0592124)
+OppRAISEChanceM [F] 0.00677199 @ $2228.75 ($204.689 now)	fold -- 0.651584	W(7.83333×)=0.123913 L=0.820583 1×o.w_s=(0.123913,0.0555043)
+Guaranteed > $28.125 is in the pot for sure
+OppFoldChance% ...    0   ∇=0
+Spot Check: If you raise, you should expect to get re-raised over the next few rounds since your hand isn't _that_ good ┋ bGamble=2
 
 *
 3c Qc Bet to call 80 (from 0) at 108.125 pot, 
@@ -151,7 +250,153 @@ Choice Optimal 80
 Choice Fold 80
 f(80)=0.987026
 CHECK/FOLD
-FoldGain()M=1.00603 by waiting 16.6667 hands(=6.17914 folds)	vs play:0.993057   ->assumes $11.25 forced
+FoldGainₘ()=1.00603 by waiting 16.6667 hands(=6.17914 folds)	vs play:0.993057   ->assumes $11.25 forced
+ AgainstCall(80)=1.00391 from +$19.8824 @ 0.594999
+AgainstRaise(80)=0.989188 from -$80 @ 0.405001
+        Push(80)=1 from $0 @ 0
+ AgainstCall(160)=1.00143 from +$20.2901 @ 0.212877
+AgainstRaise(160)=0.958067 from -$160 @ 0.787123
+        Push(160)=1 from $0 @ 0
+"all fold" precision will be 0.00452489
+OppRAISEChanceM [*] 0 @ $160 ($80 now)	fold -- 0.0	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+OppRAISEChanceM [*] 0 @ $240 ($80 now)	fold -- 0.0542986	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+OppRAISEChanceM [F] 0.405001 @ $400 ($92.0726 now)	fold -- 0.262443	W(5.16667×)=0.150036 L=0.809296 1×o.w_s=(0.150036,0.040668)
+OppRAISEChanceM [F] 0.197669 @ $720 ($126.258 now)	fold -- 0.511312	W(6.5×)=0.136528 L=0.815437 1×o.w_s=(0.136528,0.0480349)
+OppRAISEChanceM [F] 0.0776309 @ $1360 ($169.225 now)	fold -- 0.656109	W(8.5×)=0.118932 L=0.821856 1×o.w_s=(0.118932,0.0592124)
+OppRAISEChanceM [F] 0.00451977 @ $2228.75 ($207.748 now)	fold -- 0.651584	W(7.83333×)=0.123913 L=0.820583 1×o.w_s=(0.123913,0.0555043)
+
+(Fixed at $80)	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+	--
+Why didn't I raise to $160?
+"all fold" precision will be 0.00452489
+OppRAISEChanceM [*] 0.435862 @ $240 ($80 now)	fold -- 0.0542986	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+OppRAISEChanceM [F] 0.787123 @ $400 ($80 now)	fold -- 0.262443	W(5.16667×)=0.150036 L=0.809296 1×o.w_s=(0.150036,0.040668)
+OppRAISEChanceM [F] 0.556812 @ $720 ($119.064 now)	fold -- 0.511312	W(6.5×)=0.136528 L=0.815437 1×o.w_s=(0.136528,0.0480349)
+OppRAISEChanceM [F] 0.242647 @ $1360 ($164.75 now)	fold -- 0.656109	W(8.5×)=0.118932 L=0.821856 1×o.w_s=(0.118932,0.0592124)
+OppRAISEChanceM [F] 0.00677199 @ $2228.75 ($204.689 now)	fold -- 0.651584	W(7.83333×)=0.123913 L=0.820583 1×o.w_s=(0.123913,0.0555043)
+Guaranteed > $28.125 is in the pot for sure
+OppFoldChance% ...    0   ∇=0
+Spot Check: If you raise, you should expect to get re-raised over the next few rounds since your hand isn't _that_ good ┋ bGamble=3
+
+*
+3c Qc Bet to call 80 (from 0) at 108.125 pot, 
+Community outcomes (stdev = 0.125559 pcts , avgdev = 0.0865001 pcts ), kurtosis = 3.30048
+0.434497 pct: least helpful community
+0.446391 pct: 24 / 47 (51.0638%)
+0.530936 pct (mean): mean- 0.553191   mean+ 0.446809 (skew 1.96034 tail right) 
+0.549805 pct: 14 / 47 (29.7872%)
+0.591063 pct: 5 / 47 (10.6383%)
+0.671992 pct: 0 / 47 (0%)
+0.739847 pct: 0 / 47 (0%)
+0.807703 pct: 0 / 47 (0%)
+0.897011 pct: 4 / 47 (8.51064%)
+0.909486 pct: most helpful community
+CallStrength W(1m)=0.486948 L=0.425076 o.w_s=(0.486948,0.087976)
+(MinRaise to $160) 	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+ -  stat_low geom SLIDERX - 
+8 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 80
+Choice Fold 80
+f(80)=1.00055
+CALL 80
+FoldGainₘ()=1.00603 by waiting 16.6667 hands(=6.17914 folds)	vs play:1.00658   ->assumes $11.25 forced
+ AgainstCall(80)=1.00658 from +$19.8824 @ 1
+AgainstRaise(80)=1 from $0 @ 0
+        Push(80)=1 from $0 @ 0
+ AgainstCall(160)=1.00143 from +$20.2901 @ 0.212877
+AgainstRaise(160)=0.958067 from -$160 @ 0.787123
+        Push(160)=1 from $0 @ 0
+"all fold" precision will be 0.00452489
+OppRAISEChanceM [*] 0 @ $160 ($80 now)	fold -- 0.0	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+OppRAISEChanceM [*] 0 @ $240 ($80 now)	fold -- 0.0542986	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+OppRAISEChanceM [*] 0 @ $400 ($92.0726 now)	fold -- 0.262443	W(5.16667×)=0.150036 L=0.809296 1×o.w_s=(0.150036,0.040668)
+OppRAISEChanceM [*] 0 @ $720 ($126.258 now)	fold -- 0.511312	W(6.5×)=0.136528 L=0.815437 1×o.w_s=(0.136528,0.0480349)
+OppRAISEChanceM [*] 0 @ $1360 ($169.225 now)	fold -- 0.656109	W(8.5×)=0.118932 L=0.821856 1×o.w_s=(0.118932,0.0592124)
+OppRAISEChanceM [*] 0 @ $2228.75 ($207.748 now)	fold -- 0.651584	W(7.83333×)=0.123913 L=0.820583 1×o.w_s=(0.123913,0.0555043)
+
+(Fixed at $80)	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+	--
+Why didn't I raise to $160?
+"all fold" precision will be 0.00452489
+OppRAISEChanceM [*] 0.435862 @ $240 ($80 now)	fold -- 0.0542986	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+OppRAISEChanceM [F] 0.787123 @ $400 ($80 now)	fold -- 0.262443	W(5.16667×)=0.150036 L=0.809296 1×o.w_s=(0.150036,0.040668)
+OppRAISEChanceM [F] 0.556812 @ $720 ($119.064 now)	fold -- 0.511312	W(6.5×)=0.136528 L=0.815437 1×o.w_s=(0.136528,0.0480349)
+OppRAISEChanceM [F] 0.242647 @ $1360 ($164.75 now)	fold -- 0.656109	W(8.5×)=0.118932 L=0.821856 1×o.w_s=(0.118932,0.0592124)
+OppRAISEChanceM [F] 0.00677199 @ $2228.75 ($204.689 now)	fold -- 0.651584	W(7.83333×)=0.123913 L=0.820583 1×o.w_s=(0.123913,0.0555043)
+Guaranteed > $28.125 is in the pot for sure
+OppFoldChance% ...    0   ∇=0
+Spot Check: If you raise, you should expect to get re-raised over the next few rounds since your hand isn't _that_ good ┋ bGamble=4
+
+*
+3c Qc Bet to call 80 (from 0) at 108.125 pot, 
+Community outcomes (stdev = 0.125559 pcts , avgdev = 0.0865001 pcts ), kurtosis = 3.30048
+0.434497 pct: least helpful community
+0.446391 pct: 24 / 47 (51.0638%)
+0.530936 pct (mean): mean- 0.553191   mean+ 0.446809 (skew 1.96034 tail right) 
+0.549805 pct: 14 / 47 (29.7872%)
+0.591063 pct: 5 / 47 (10.6383%)
+0.671992 pct: 0 / 47 (0%)
+0.739847 pct: 0 / 47 (0%)
+0.807703 pct: 0 / 47 (0%)
+0.897011 pct: 4 / 47 (8.51064%)
+0.909486 pct: most helpful community
+CallStrength W(1m)=0.486948 L=0.425076 o.w_s=(0.486948,0.087976)
+(MinRaise to $160) 	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+ -  stat_high algb SLIDERX - 
+8 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 80
+Choice Fold 80
+f(80)=1.00055
+CALL 80
+FoldGainₘ()=1.00603 by waiting 16.6667 hands(=6.17914 folds)	vs play:1.00658   ->assumes $11.25 forced
+ AgainstCall(80)=1.00658 from +$19.8824 @ 1
+AgainstRaise(80)=1 from $0 @ 0
+        Push(80)=1 from $0 @ 0
+ AgainstCall(160)=1.00175 from +$24.8321 @ 0.212877
+AgainstRaise(160)=0.958307 from -$160 @ 0.787123
+        Push(160)=1 from $0 @ 0
+"all fold" precision will be 0.00452489
+OppRAISEChanceM [*] 0 @ $160 ($80 now)	fold -- 0.0	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+OppRAISEChanceM [*] 0 @ $240 ($80 now)	fold -- 0.0542986	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+OppRAISEChanceM [*] 0 @ $400 ($92.0726 now)	fold -- 0.262443	W(5.16667×)=0.150036 L=0.809296 1×o.w_s=(0.150036,0.040668)
+OppRAISEChanceM [*] 0 @ $720 ($126.258 now)	fold -- 0.511312	W(6.5×)=0.136528 L=0.815437 1×o.w_s=(0.136528,0.0480349)
+OppRAISEChanceM [*] 0 @ $1360 ($169.225 now)	fold -- 0.656109	W(8.5×)=0.118932 L=0.821856 1×o.w_s=(0.118932,0.0592124)
+OppRAISEChanceM [*] 0 @ $2228.75 ($207.748 now)	fold -- 0.651584	W(7.83333×)=0.123913 L=0.820583 1×o.w_s=(0.123913,0.0555043)
+
+(Fixed at $80)	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+	--
+Why didn't I raise to $160?
+"all fold" precision will be 0.00452489
+OppRAISEChanceM [*] 0.435862 @ $240 ($80 now)	fold -- 0.0542986	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+OppRAISEChanceM [F] 0.787123 @ $400 ($80 now)	fold -- 0.262443	W(5.16667×)=0.150036 L=0.809296 1×o.w_s=(0.150036,0.040668)
+OppRAISEChanceM [F] 0.556812 @ $720 ($119.064 now)	fold -- 0.511312	W(6.5×)=0.136528 L=0.815437 1×o.w_s=(0.136528,0.0480349)
+OppRAISEChanceM [F] 0.242647 @ $1360 ($164.75 now)	fold -- 0.656109	W(8.5×)=0.118932 L=0.821856 1×o.w_s=(0.118932,0.0592124)
+OppRAISEChanceM [F] 0.00677199 @ $2228.75 ($204.689 now)	fold -- 0.651584	W(7.83333×)=0.123913 L=0.820583 1×o.w_s=(0.123913,0.0555043)
+Guaranteed > $28.125 is in the pot for sure
+OppFoldChance% ...    0   ∇=0
+
+*
+3c Qc Bet to call 80 (from 0) at 108.125 pot, 
+Community outcomes (stdev = 0.125559 pcts , avgdev = 0.0865001 pcts ), kurtosis = 3.30048
+0.434497 pct: least helpful community
+0.446391 pct: 24 / 47 (51.0638%)
+0.530936 pct (mean): mean- 0.553191   mean+ 0.446809 (skew 1.96034 tail right) 
+0.549805 pct: 14 / 47 (29.7872%)
+0.591063 pct: 5 / 47 (10.6383%)
+0.671992 pct: 0 / 47 (0%)
+0.739847 pct: 0 / 47 (0%)
+0.807703 pct: 0 / 47 (0%)
+0.897011 pct: 4 / 47 (8.51064%)
+0.909486 pct: most helpful community
+CallStrength W(1m)=0.486948 L=0.425076 o.w_s=(0.486948,0.087976)
+(MinRaise to $160) 	W(1×)=0.486948 L=0.425076 1×o.w_s=(0.486948,0.087976)
+ -  statrelation geom RAW - 
+8 dealt, 1 opp. (round), 1 opp. assumed str., 1 opp. still in
+Choice Optimal 80
+Choice Fold 80
+f(80)=0.987026
+CHECK/FOLD
+FoldGainₘ()=1.00603 by waiting 16.6667 hands(=6.17914 folds)	vs play:0.993057   ->assumes $11.25 forced
  AgainstCall(80)=1.00391 from +$19.8824 @ 0.594999
 AgainstRaise(80)=0.989188 from -$80 @ 0.405001
         Push(80)=1 from $0 @ 0

--- a/holdem/unittests/playlogs.expected/9.txt
+++ b/holdem/unittests/playlogs.expected/9.txt
@@ -32,7 +32,7 @@ Choice Optimal 2.25
 Choice Fold 3
 f(2.25)=1.00071
 CALL 2.25
-FoldGain()R=0.999522 by waiting 0 hands(=0 folds)	vs play:1.00023
+FoldGainᵣ()=0.999522 by waiting 0 hands(=0 folds)	vs play:1.00023
  AgainstCall(2.25)=1.00201 from +$3.32088 @ 0.434094
 AgainstRaise(2.25)=0.998224 from -$2.25 @ 0.565906
         Push(2.25)=1 from $0 @ 0
@@ -88,7 +88,7 @@ Choice Optimal 5
 Choice Fold 10
 f(5)=1.00415
 CALL 5
-FoldGain()R=0.996862 by waiting 0 hands(=0 folds)	vs play:1.00101
+FoldGainᵣ()=0.996862 by waiting 0 hands(=0 folds)	vs play:1.00101
  AgainstCall(5)=1.00251 from +$2.29299 @ 0.785153
 AgainstRaise(5)=0.998502 from -$5 @ 0.214847
         Push(5)=1 from $0 @ 0
@@ -154,7 +154,7 @@ Choice Optimal 12.5
 Choice Fold 711
 f(12.5)=1.02545
 CALL 12.5
-FoldGain()M=0.992978 by waiting 0 hands(=0 folds)	vs play:1.01843
+FoldGainₘ()=0.992978 by waiting 0 hands(=0 folds)	vs play:1.01843
  AgainstCall(12.5)=1.01973 from +$15.1754 @ 0.925721
 AgainstRaise(12.5)=0.998696 from -$12.5 @ 0.0742785
         Push(12.5)=1 from $0 @ 0
@@ -215,7 +215,7 @@ Choice Optimal 49
 Choice Fold 49
 f(49)=0.993131
 CHECK/FOLD
-FoldGain()M=1.02789 by waiting 21.6667 hands(=4.72518 folds)	vs play:1.02102
+FoldGainₘ()=1.02789 by waiting 21.6667 hands(=4.72518 folds)	vs play:1.02102
  AgainstCall(49)=1.04049 from +$39.2288 @ 0.722059
 AgainstRaise(49)=0.98053 from -$49 @ 0.277941
         Push(49)=1 from $0 @ 0

--- a/holdem/unittests/playlogs.expected/d_dw.txt
+++ b/holdem/unittests/playlogs.expected/d_dw.txt
@@ -26,7 +26,7 @@ Choice Optimal 10
 Choice Fold 50
 f(10)=1.01738
 CALL 10
-FoldGain()R=0.998385 by waiting 0 hands(=0 folds)	vs play:1.01576
+FoldGainᵣ()=0.998385 by waiting 0 hands(=0 folds)	vs play:1.01576
  AgainstCall(10)=1.00577 from $1.00794 @ 0.726998
 AgainstRaise(10)=1.00994 from $1.03689 @ 0.273002
         Push(10)=1 from $1 @ 0
@@ -82,7 +82,7 @@ Choice Optimal 0
 Choice Fold 20
 f(0)=1.01586
 CALL 0
-FoldGain()R=0.988235 by waiting 0 hands(=0 folds)	vs play:1.0041
+FoldGainᵣ()=0.988235 by waiting 0 hands(=0 folds)	vs play:1.0041
  AgainstCall(0)=1.0041 from $1.00995 @ 0.413068
 AgainstRaise(0)=1 from $1 @ 0.586932
         Push(0)=1 from $1 @ 0
@@ -138,7 +138,7 @@ Choice Optimal 0
 Choice Fold 25
 f(0)=1.01914
 CALL 0
-FoldGain()R=0.988235 by waiting 0 hands(=0 folds)	vs play:1.00738
+FoldGainᵣ()=0.988235 by waiting 0 hands(=0 folds)	vs play:1.00738
  AgainstCall(0)=1.00752 from $1.01413 @ 0.534392
 AgainstRaise(0)=0.999856 from $0.99969 @ 0.465608
         Push(0)=1 from $1 @ 0
@@ -195,7 +195,7 @@ Choice Fold 850
 f(485)=-0.746267
 raiseGain: f(850)=-0.746267
 CHECK/FOLD
-FoldGain()R=2.17568 by waiting 65.3333 hands(=34.3287 folds)	vs play:0.429412
+FoldGainᵣ()=2.17568 by waiting 65.3333 hands(=34.3287 folds)	vs play:0.429412
  AgainstCall(485)=1 from $1 @ 0
 AgainstRaise(485)=0.429412 from $0.429412 @ 1
         Push(485)=1 from $1 @ 0


### PR DESCRIPTION
As far as I can tell, the point is to swap from `callIncrLoss * std::pow(callIncrBase,fw)` to `std::pow(callIncrLoss, 1 - fw) * std::pow(callIncrBase,fw)`

The test that appears to be (most)? sensitive to this change is test 006