### PR TITLE
Possible speedup for `HandPlus::SetUnique(Hand const&)`

### DIFF
--- a/holdem/src/holdemutil.cpp
+++ b/holdem/src/holdemutil.cpp
@@ -231,7 +231,6 @@ uint32 HandPlus::getValueset() const
 
 void Hand::SetEmpty()
 {
-
     cardset[0] = 0;
     cardset[1] = 0;
     cardset[2] = 0;
@@ -312,10 +311,14 @@ void Hand::AppendUnique(const Hand& h)
 
 void Hand::ResetCardset(const uint32 * const cardArray)
 {
+  #ifdef HARDCORE_SPEEDUP
+     memcpy(cardset, cardArray, sizeof(cardset));
+  #else
     cardset[0] = cardArray[0];
 	cardset[1] = cardArray[1];
 	cardset[2] = cardArray[2];
 	cardset[3] = cardArray[3];
+	#endif
 }
 
 void Hand::SetUnique(const Hand& h)

--- a/holdem/src/holdemutil.h
+++ b/holdem/src/holdemutil.h
@@ -21,6 +21,9 @@
 #ifndef HOLDEM_BaseClasses
 #define HOLDEM_BaseClasses
 
+// Use fine-tuning of data/memory layout to find runtime performance & cache locality improvements
+#define HARDCORE_SPEEDUP
+
 #define FASTPATH_NCHOOSEP_IMPL \
   switch (p) { \
 	   case 0: { return 1; } \
@@ -222,10 +225,11 @@ struct DeckLocationPair {
     {}
 };
 
-
-
-class Hand
-{
+#ifdef HARDCORE_SPEEDUP
+class alignas(16) Hand {
+#else
+class Hand {
+#endif
 
 protected:
     uint32 cardset[4];


### PR DESCRIPTION
From LLMs:
"""
The `Hand` class contains a single member, `cardset`, which is an array of four `uint32` values. This is good news for performance, as there's no other data in the class to interfere with cache alignment.
"""