### PR TITLE
Try to speedup `HandPlus::populateValueset` [CommunityPlus::RemoveFromHand, HandPlus::AppendUnique, HandPlus::SetUnique]

### DIFF
--- a/holdem/src/holdemutil.cpp
+++ b/holdem/src/holdemutil.cpp
@@ -330,10 +330,16 @@ void HandPlus::populateValueset()
 
 	for(int8 i=13;i>=1;--i)
 	{
-		valueset += (cardset[0] & HoldemUtil::CARDORDER[i]);
-		valueset += (cardset[1] & HoldemUtil::CARDORDER[i]);
-		valueset += (cardset[2] & HoldemUtil::CARDORDER[i]);
-		valueset += (cardset[3] & HoldemUtil::CARDORDER[i]);
+	#ifdef HARDCORE_SPEEDUP
+	  // Compute directly instead of table lookup
+	  const uint32 mask = 1u << i;
+	#else
+	  const uint32 mask = HoldemUtil::CARDORDER[i];
+	#endif
+		valueset += (cardset[0] & mask);
+		valueset += (cardset[1] & mask);
+		valueset += (cardset[2] & mask);
+		valueset += (cardset[3] & mask);
 		valueset <<= 1;
 	}
 

--- a/holdem/src/holdemutil.h
+++ b/holdem/src/holdemutil.h
@@ -21,6 +21,9 @@
 #ifndef HOLDEM_BaseClasses
 #define HOLDEM_BaseClasses
 
+// Use fine-tuning of data/memory layout to find runtime performance & cache locality improvements
+#define HARDCORE_SPEEDUP
+
 #define FASTPATH_NCHOOSEP_IMPL \
   switch (p) { \
 	   case 0: { return 1; } \


### PR DESCRIPTION
* Eliminate memory access (remove one memory read)
* Better parallelism (bitshift can be computed while other instructions are in the execution pipeline)
* No cache pollution of CARDORDER array